### PR TITLE
added cleanup function to OXMODULE in OxStart.ml

### DIFF
--- a/src/OxLib/lib/OxStart.ml
+++ b/src/OxLib/lib/OxStart.ml
@@ -10,6 +10,8 @@ module type OXMODULE = sig
   val packet_in : switchId -> xid -> PacketIn.t -> unit
   val barrier_reply : switchId -> xid -> unit
   val stats_reply : switchId -> xid -> StatsReply.t -> unit
+  val cleanup : unit -> unit
+
 end
 
 module DefaultTutorialHandlers = struct
@@ -23,6 +25,8 @@ module DefaultTutorialHandlers = struct
   let barrier_reply _ _ = ()
 
   let stats_reply _ _ _ = ()
+
+  let cleanup _ = ()
 
 end
 
@@ -86,6 +90,7 @@ module Make (Handlers:OXMODULE) = struct
     try
       Lwt_main.run (start_controller ())
     with exn ->
+      Handlers.cleanup ();
       Format.printf "Unexpected exception: %s\n%s\n%!"
         (Printexc.to_string exn)
         (Printexc.get_backtrace ());

--- a/src/OxLib/lib/OxStart.mli
+++ b/src/OxLib/lib/OxStart.mli
@@ -12,6 +12,7 @@ module DefaultTutorialHandlers : sig
   val switch_disconnected : switchId -> unit
   val barrier_reply : switchId -> xid -> unit
   val stats_reply : switchId -> xid -> reply -> unit
+  val cleanup : unit -> unit
 
 end
 
@@ -39,6 +40,11 @@ module type OXMODULE = sig
   (** [stats_reply sw xid rep] is a callback invoked when switch [sw] responds
   with a reply [rep] to a statistics request with transaction ID [xid]. *)
   val stats_reply : switchId -> xid -> reply -> unit
+
+  (** [cleanup] is called when an exception stops the running of the main
+  controller loop. *)
+  val cleanup : unit -> unit
+
 
 end
 


### PR DESCRIPTION
This adds a function with signature

val cleanup : unit -> unit

to OXMODULE in OxStart.ml and OxStart.mli in src/OxLib/lib. The cleanup function is called in the main run loop of Make when an exception is caught.
