### PR TITLE
Fixed link in Makefile

### DIFF
--- a/src/frenetic/Makefile
+++ b/src/frenetic/Makefile
@@ -10,7 +10,7 @@ configure:
 
 build: configure
 	$(OCAML) setup.ml -build
-	sudo ln -sf `pwd`/frenetic.byte /usr/local/bin/frenetic
+	sudo ln -sf `pwd`/Frenetic.byte /usr/local/bin/frenetic
 
 clean:
 	$(OCAML) setup.ml -clean


### PR DESCRIPTION
The build process generates Frenetic.byte but the Makefile incorrectly linked frenetic.byte.
