### PR TITLE
Fix bug in regex_of_policy for certain seq cases

### DIFF
--- a/lib/NetKAT_Automaton.ml
+++ b/lib/NetKAT_Automaton.ml
@@ -209,11 +209,29 @@ let regex_of_policy (p : policy) : regex =
     end
 
   and rpc_seq i j =
+    (* The following match impelements this "truth table" for the inter type:
+     *
+     *    a  | b  | a ; b
+     *   ----+----+-------
+     *    TP | TP | TP
+     *    TP | NL | NL
+     *    TP | S  | TP
+     *    NL | TP | TP
+     *    NL | NL | NL
+     *    NL | S  | <<error>>
+     *    S  | TP | S
+     *    S  | NL | NL
+     *    S  | S  | S
+     *
+     *  Note that in the NL, TP case below, calling f1 with None as the second
+     *  argument will force a transition to TP, thus satisfying the truth table
+     *  above.
+     * *)
     begin match i, j with
       | TP f1, NL f2 -> NL(fun c mlf_p mlp -> rpc_seq (f1 c mlf_p) (f2 c None mlp))
       | TP f1, _     -> let r = run j in TP(fun c mp -> rpc_seq (f1 c mp) (S(r)))
       | NL f1, TP f2 -> f1 seq None (Some f2)
-      | NL f1, NL f2 -> f1 seq None (Some(fun c mlf_q -> f2 c mlf_q None))
+      | NL f1, NL f2 -> NL(fun c mlf_p mlp -> f1 seq mlf_p (Some(fun c mlf_q -> f2 c mlf_q mlp)))
       | NL f1, S  r  -> failwith "Cat(NL, Star) can't be represented"
       | S   r, _     -> s_trans r j (fun x y -> Cat(x, y))
     end


### PR DESCRIPTION
In certain cases, the transformation wasn't using the fact that
sequencing is associative. For example in this program

```
(filter switch = 1; port := 1 ;
  (1@1 => 2@1; filter switch = 2; port := 4)); 9@2 => 2@3
```

the transformation descends to the sequence of the link and the filter
on switch = 2. The link term will create a TP continuation, and the
filter will crate an NL continuation. The sequencing rule for TP, NL
would properly create a NL continuation in this case. But, if this NL
continuation is ever called with None as its second argument (indicating
no link-free policies are available), it will force the TP continuation
to turn the link into a character.

This is exactly what happens once you go up one constructor level,
where you're dealing with this expression:

  `(1@1 => 2@1; filter switch = 2); port := 4`

The left-hand side is the aforementioned NL continuation with the
embedded TP call. Passing that continuation None as its second argument
forced the link to become a character, causing the error.

What this code should have done is create a new NL continuation that
will be able to receive more link-free policies from its context, and
pass those along.

I've added an ascii "truth-table" showing the valid continuation
transitions. In the case of NL, NL, it should always transition to NL,
but just forcing the left-hand side continuation does not ensure that in
the general case. Therefore, you have to wrap the call in the proper
constructor.

Closes #152.
