### PR TITLE
Make the LocalCompiler more local

### DIFF
--- a/frenetic/netkat_test.ml
+++ b/frenetic/netkat_test.ml
@@ -74,8 +74,8 @@ end
 
 let () =
   let local p =
-    let i = LocalCompiler.RunTime.compile p in
-    (fun sw -> LocalCompiler.RunTime.to_table sw i) in
+    (fun sw -> LocalCompiler.RunTime.to_table 
+      (LocalCompiler.RunTime.compile sw p)) in
   print_string (Example.pol_str ^ "\n\n");
   let pol = Parser.program Lexer.token (Lexing.from_string Example.pol_str) in
   Lwt_main.run (Controller.start local 6633 (NetKAT_Stream.constant pol))

--- a/lib/LocalCompiler.ml
+++ b/lib/LocalCompiler.ml
@@ -525,21 +525,26 @@ module Local = struct
       (fun ri acc -> extend ri [Action.id] acc) 
       rs Atom.Map.empty
 
-  let rec of_pred (pr:Types.pred) : t =
+  let rec of_pred (sw:SDN_Types.fieldVal) (pr:Types.pred) : t =
     match pr with
       | Types.True ->
         Atom.Map.singleton Atom.tru [Action.id]
       | Types.False ->
         Atom.Map.empty
       | Types.Neg p ->
-        negate (of_pred p)
+        negate (of_pred sw p)
+      | Types.Test (Types.Switch, v) ->
+        if v = sw then 
+          of_pred sw Types.True
+        else
+          of_pred sw Types.False 
       | Types.Test (h, v) ->
         let p = Types.HeaderMap.singleton h v in
         Atom.Map.singleton (Pattern.Set.empty, p) [Action.id]
       | Types.And (pr1, pr2) ->
-        seq_local (of_pred pr1) (of_pred pr2)
+        seq_local (of_pred sw pr1) (of_pred sw pr2)
       | Types.Or (pr1, pr2) ->
-        par_local (of_pred pr1) (of_pred pr2)
+        par_local (of_pred sw pr1) (of_pred sw pr2)
 
   let star_local (p:t) : t =
     let rec loop acc pi =
@@ -552,20 +557,20 @@ module Local = struct
     let p0 = Atom.Map.singleton Atom.tru [Action.id] in
     loop p0 p0
 
-  let rec of_policy (pol:Types.policy) : t =
+  let rec of_policy (sw:SDN_Types.fieldVal) (pol:Types.policy) : t =
     match pol with
       | Types.Filter pr ->
-        of_pred pr
+        of_pred sw pr
       | Types.Mod (h, v) ->
         Atom.Map.singleton Atom.tru [Action.Set.singleton (Types.HeaderMap.singleton h v)]
       | Types.Par (pol1, pol2) ->
-        par_local (of_policy pol1) (of_policy pol2)
+        par_local (of_policy sw pol1) (of_policy sw pol2)
       | Types.Choice (pol1, pol2) ->
-        choice_local (of_policy pol1) (of_policy pol2)
+        choice_local (of_policy sw pol1) (of_policy sw pol2)
       | Types.Seq (pol1, pol2) ->
-        seq_local (of_policy pol1) (of_policy pol2)
+        seq_local (of_policy sw pol1) (of_policy sw pol2)
       | Types.Star pol ->
-        star_local (of_policy pol)
+        star_local (of_policy sw pol)
       | Types.Link(sw,pt,sw',pt') ->
 	failwith "Not a local policy"
 
@@ -636,21 +641,18 @@ module RunTime = struct
   let group_to_action (g:Action.group) (pto:VInt.t option) : SDN_Types.group =
     List.map (fun s -> set_to_action s pto) g
 
-  let to_pattern (sw : SDN_Types.fieldVal) (x:Pattern.t) : SDN_Types.pattern option =
+  let to_pattern (x:Pattern.t) : SDN_Types.pattern =
     let f (h : Types.header) (v : Types.header_val) (pat : SDN_Types.pattern) =
       match h with
-        | Types.Switch -> pat (* already tested for this *)
+        | Types.Switch -> 
+          raise (Invalid_argument "RunTime.to_pattern: unexpected switch")
         | Types.Header h' -> SDN_Types.FieldMap.add h' v pat in
-    if Types.HeaderMap.mem Types.Switch x &&
-      Types.HeaderMap.find Types.Switch x <> sw then
-      None
-    else
-      Some (Types.HeaderMap.fold f x SDN_Types.FieldMap.empty)
+    Types.HeaderMap.fold f x SDN_Types.FieldMap.empty
 
   type i = Local.t
 
-  let compile (pol:Types.policy) : i =
-    let r = Local.of_policy pol in 
+  let compile (sw:SDN_Types.fieldVal) (pol:Types.policy) : i =
+    let r = Local.of_policy sw pol in 
     (* Printf.printf "COMPILE\n%s\n%s\n" *)
     (*   (Pretty.string_of_policy pol) *)
     (*   (Local.to_string r); *)
@@ -668,18 +670,14 @@ module RunTime = struct
   }
 
   (* Prunes out rules that apply to other switches. *)
-  let to_table (sw:SDN_Types.fieldVal) (p:i) : SDN_Types.flowTable =
+  let to_table (p:i) : SDN_Types.flowTable =
     let add_flow x g l =
       let pto = 
         try 
           Some (Types.HeaderMap.find (Types.Header SDN_Types.InPort) x) 
         with Not_found -> 
           None in 
-      match to_pattern sw x with
-        | None ->
-          l
-        | Some pat ->
-          simpl_flow pat (group_to_action g pto) :: l in
+      simpl_flow (to_pattern x) (group_to_action g pto) :: l in
     let rec loop (p:i) acc cover =
       if Atom.Map.is_empty p then
         acc

--- a/lib/LocalCompiler.mli
+++ b/lib/LocalCompiler.mli
@@ -42,14 +42,14 @@ end
   
 module Local : sig
   type t = Action.group Atom.Map.t
-  val of_policy : Types.policy -> t
+  val of_policy : SDN_Types.fieldVal -> Types.policy -> t
   val to_netkat : t -> Types.policy
 end
 
 module RunTime : sig 
   (* intermediate form *)
   type i 
-  val compile : Types.policy -> i
+  val compile : SDN_Types.fieldVal -> Types.policy -> i
   val decompile : i -> Types.policy
-  val to_table : SDN_Types.fieldVal -> i -> SDN_Types.flowTable 
+  val to_table : i -> SDN_Types.flowTable 
 end

--- a/test/NetKAT_Test.ml
+++ b/test/NetKAT_Test.ml
@@ -5,7 +5,9 @@ open Types
 open Pretty
 
 let test_compile lhs rhs =
-  let rhs' = LocalCompiler.Local.to_netkat (LocalCompiler.Local.of_policy lhs) in
+  let rhs' = 
+    LocalCompiler.Local.to_netkat
+      (LocalCompiler.Local.of_policy (VInt.Int64 0L) lhs) in
   if rhs' = rhs then
     true
   else
@@ -15,7 +17,7 @@ let test_compile lhs rhs =
 
 let test_compile_table pol tbl = 
   let open LocalCompiler.RunTime in 
-  let tbl' = to_table (VInt.Int64 0L) (compile pol) in 
+  let tbl' = to_table (compile (VInt.Int64 0L) pol) in 
   if tbl = tbl' then 
     true
   else


### PR DESCRIPTION
- thread switch argument through compilation
- interpret Test on Switch at compile time
- this means that a flow table is only for one switch

Slower, but simpler. And correct-ier.
- Also fixed up front-end and unit test code in light of this change.
