### PR TITLE
use cached .opam

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -20,8 +20,7 @@ echo OPAM versions
 opam --version
 opam --git-version
 
-
-opam init
+(cd $HOME && curl "https://s3.amazonaws.com/opam-street/opam-street.tar.gz" | tar xz)
 eval `opam config env`
 export CAML_LD_LIBRARY_PATH="$EXTRA_LD_LIBRARY_PATH:$CAML_LD_LIBRARY_PATH"
 opam install ${OPAM_DEPENDS}


### PR DESCRIPTION
Rather than rebuilding the Jane Street libraries and cstruct for each build, this commit will use a pickled .opam directory containing those prebuilt libraries and copy that in place.

This has been tested using [seliopou/frenetic](https://github.com/seliopou/frenetic) ([travis-ci build](https://travis-ci.org/seliopou/frenetic/builds/18110480)). See [seliopou/opam-street](https://github.com/seliopou/opam-street) to see how the picked opam is created.
