### PR TITLE
Fix Pattern diff.

### DIFF
--- a/lib/NetKAT_LocalCompiler.ml
+++ b/lib/NetKAT_LocalCompiler.ml
@@ -1078,6 +1078,6 @@ let to_netkat =
 let compile =
   RunTime.compile
 
-let to_table ?(optimize_fall_through=false) t =
+let to_table ?(optimize_fall_through=true) t =
   Local_Optimize.remove_shadowed_rules
     (RunTime.to_table t ~optimize_fall_through:optimize_fall_through)


### PR DESCRIPTION
`Pattern.diff` was not right. This fixes a bug in the fallthrough elimination optimization as witnessed by the following NetKAT program:

```
(filter not (ethTyp = 0x5ff); filter port = 1) | 
(filter ethTyp = 0x806; port := 2)
```

@jnfoster let me know if this looks like it makes sense.
