### PR TITLE
add stubs for functions in new topology API

### DIFF
--- a/async/Async_NetKAT.ml
+++ b/async/Async_NetKAT.ml
@@ -22,6 +22,8 @@ module Node = struct
 
   let parse_dot _ _ = failwith "NYI: Node.parse_dot"
   let parse_gml _ = failwith "NYI: Node.parse_dot"
+
+  let to_dot _ = failwith "NYI: Node.to_dot"
 end
 
 module Link = struct
@@ -34,6 +36,8 @@ module Link = struct
 
   let parse_dot _ = failwith "NYI: Link.parse_dot"
   let parse_gml _ = failwith "NYI: Link.parse_dot"
+
+  let to_dot _ = failwith "NYI: Link.to_dot"
 end
 
 module Net = Network.Make(Node)(Link)


### PR DESCRIPTION
Depends on frenetic-lang/ocaml-topology#36
