### PR TITLE
Make send/recv records not effectively opaque

### DIFF
--- a/async/Async_NetKAT.mli
+++ b/async/Async_NetKAT.mli
@@ -35,7 +35,15 @@ type app
     variant of [update]. *)
 type update = Raw_app.update
 
-type recv = policy Raw_app.recv
+type send = {
+  pkt_out : (switchId * SDN_Types.pktOut) Pipe.Writer.t;
+  update  : policy Pipe.Writer.t
+}
+
+type recv = {
+  pkt_out : (switchId * SDN_Types.pktOut) Pipe.Reader.t;
+  update  : policy Pipe.Reader.t
+}
 
 (** The set of pipe names that an application is listening on. *)
 module PipeSet : Set.S
@@ -58,7 +66,7 @@ type handler
     indicates a partial application point. *)
 type async_handler
   = Net.Topology.t ref
-  -> policy Raw_app.send
+  -> send
   -> unit
   -> event -> result Deferred.t
 

--- a/async/Async_NetKAT_Controller.ml
+++ b/async/Async_NetKAT_Controller.ml
@@ -564,8 +564,6 @@ let start app ?(port=6633) ?(update=`BestEffort) ?(policy_queue_size=0) () =
       implement_policy t (Queue.get q (len - 1))
     in
 
-    Pipe.set_size_budget recv.Raw_app.update policy_queue_size;
-
     (* This is the main event handler for the controller. First it sends
      * events to the application callback. Then it checks to see if the event
      * is a SwitchUp event, in which case it's necessary to populate the new
@@ -582,8 +580,10 @@ let start app ?(port=6633) ?(update=`BestEffort) ?(policy_queue_size=0) () =
     (* Combine the pkt_out messages receied from the application and those that
      * are generated from evaluating the policy at the controller.
      * *)
-    let open Raw_app in
+    let open Async_NetKAT in
     let pkt_outs = Pipe.interleave [r_pkt_out; recv.pkt_out] in
+
+    Pipe.set_size_budget recv.update policy_queue_size;
 
     (* Kick off the three top-level logical threads of the controller. The
      * first handles incoming events from switches. The second sends pkt_out


### PR DESCRIPTION
The `Raw_app` module is not exported, which means that a user previously could not inspect the fields of a send/recv struct when using netkat as an external library. This commit fixes that situation by explicitly
defining the record in `Async_NetKAT`.
