### PR TITLE
remove opaque/unused update type

### DIFF
--- a/async/Async_NetKAT.ml
+++ b/async/Async_NetKAT.ml
@@ -56,8 +56,6 @@ exception Sequence_error of PipeSet.t * PipeSet.t
 
 type app = (Net.Topology.t ref) Raw_app.t
 
-type update = Raw_app.update
-
 type send = {
   pkt_out : (switchId * SDN_Types.pktOut) Pipe.Writer.t;
   update  : policy Pipe.Writer.t

--- a/async/Async_NetKAT.mli
+++ b/async/Async_NetKAT.mli
@@ -25,16 +25,6 @@ module Net : Network.NETWORK
     parts. *)
 type app
 
-(** [update] represents a policy upate for asychronous applications. When
-    responding to a network event, applications must write either an
-    [Event(pol)] or [EventNoop] [update] before allow the returned
-    [unit Deferred.t] to become determined. A good way to do this is to have
-    that write be in the the return position of your event callback.
-
-    All asychronous policy updates should exclusively use the [Async(pol)]
-    variant of [update]. *)
-type update = Raw_app.update
-
 type send = {
   pkt_out : (switchId * SDN_Types.pktOut) Pipe.Writer.t;
   update  : policy Pipe.Writer.t


### PR DESCRIPTION
This was left over from when more of the `Raw_app` API was exposed from `Async_NetKAT`. This type is no longer necessary, nor can it be of any real use to clients of this library.
