### PR TITLE
use shared pipe record for send/recv

### DIFF
--- a/async/Async_NetKAT.ml
+++ b/async/Async_NetKAT.ml
@@ -56,15 +56,13 @@ exception Sequence_error of PipeSet.t * PipeSet.t
 
 type app = (Net.Topology.t ref) Raw_app.t
 
-type send = {
-  pkt_out : (switchId * SDN_Types.pktOut) Pipe.Writer.t;
-  update  : policy Pipe.Writer.t
+type 'phantom pipes = {
+  pkt_out : (switchId * SDN_Types.pktOut, 'phantom) Pipe.t;
+  update  : (policy, 'phantom) Pipe.t
 }
 
-type recv = {
-  pkt_out : (switchId * SDN_Types.pktOut) Pipe.Reader.t;
-  update  : policy Pipe.Reader.t
-}
+type send = Pipe.Writer.phantom pipes
+type recv = Pipe.Reader.phantom pipes
 
 type result = policy option
 type handler

--- a/async/Async_NetKAT.mli
+++ b/async/Async_NetKAT.mli
@@ -25,15 +25,13 @@ module Net : Network.NETWORK
     parts. *)
 type app
 
-type send = {
-  pkt_out : (switchId * SDN_Types.pktOut) Pipe.Writer.t;
-  update  : policy Pipe.Writer.t
+type 'phantom pipes = {
+  pkt_out : (switchId * SDN_Types.pktOut, 'phantom) Pipe.t;
+  update  : (policy, 'phantom) Pipe.t
 }
 
-type recv = {
-  pkt_out : (switchId * SDN_Types.pktOut) Pipe.Reader.t;
-  update  : policy Pipe.Reader.t
-}
+type send = Pipe.Writer.phantom pipes
+type recv = Pipe.Reader.phantom pipes
 
 (** The set of pipe names that an application is listening on. *)
 module PipeSet : Set.S


### PR DESCRIPTION
The send/recv records have the same fields with the same types, with the exception that send contains writer pipes and recv contains reader pipes. To avoid failures of the compiler to disambiguate based on types, the code now uses a single record type parameterized by the phantom type that distinguishes between a reader and writer pipe.

Depends on #321.
