### PR TITLE
Improve implementations of create_static and guard.

### DIFF
--- a/async/Async_NetKAT.ml
+++ b/async/Async_NetKAT.ml
@@ -134,9 +134,9 @@ let seq (app1 : app) (app2 : app) : app =
   Raw_app.combine ~how:`Sequential (fun x y -> Seq(x, y)) app1 app2
 
 let guard (pred : pred) (app : app) : app =
-  Raw_app.guard pred app
+  seq (create_static (Filter pred)) app
 
 let slice (pred : pred) (app1 : app) (app2 : app) : app =
   union ~how:`Parallel
-    (Raw_app.guard pred       app1)
-    (Raw_app.guard (Neg pred) app2)
+    (guard pred       app1)
+    (guard (Neg pred) app2)

--- a/async/raw_app.ml
+++ b/async/raw_app.ml
@@ -298,14 +298,3 @@ let combine
           ]
     )
   }
-
-let guard (pred : pred) (app : 'a t) : 'a t =
-  { pipes = app.pipes
-  ; policy = Seq(Filter pred, app.policy)
-  ; handler = `Composite(fun a send () ->
-      let recv, callback = run app a () in
-      Deferred.don't_wait_for (Pipe.transfer_id recv.pkt_out send.pkt_out);
-      Deferred.don't_wait_for (Pipe.transfer    recv.update  send.update
-        ~f:(fun pol -> Seq(Filter pred, pol)));
-      callback)
-  }


### PR DESCRIPTION
This pull request replaces the implementations of `create_static` with a custom implementation that does a better job of managing update pipes. Specifically, the new implementation closes both the `update` and `pkt_out` pipes, as they will never be used.

This pull request also replaces the custom implementation of `guard` in favor of one in terms of `create_static`.
