### PR TITLE
pipe_pred: do not compile policies with pipes in preds

### DIFF
--- a/lib/NetKAT_LocalCompiler.ml
+++ b/lib/NetKAT_LocalCompiler.ml
@@ -927,6 +927,9 @@ module RunTime = struct
   let expand_rules (x:Pattern.t) (s:Action.Set.t) : flowTable =
     let m : HPT.t = 
       let open HPT in 
+      List.iter x.HPT.location ~f:(function
+        | (Some(NetKAT_Types.Pipe _), _) -> failwith "indetermiate port in pattern"
+        | _                              -> ());
       { location = PTL.(expand x.HPT.location);
         ethSrc = PT48.(expand x.HPT.ethSrc);
         ethDst = PT48.(expand x.HPT.ethDst);

--- a/quickcheck/NetKAT_Arbitrary.ml
+++ b/quickcheck/NetKAT_Arbitrary.ml
@@ -24,7 +24,6 @@ let arbitrary_test, arbitrary_mod =
   let open NetKAT_Types in
   let shared = [
     map_gen (fun i -> Location (Physical i)) AB.arbitrary_uint32;
-    map_gen (fun s -> Location (Pipe s)) arbitrary_id;
     map_gen (fun i -> EthSrc i) AB.arbitrary_uint48;
     map_gen (fun i -> EthDst i) AB.arbitrary_uint48;
     map_gen (fun i -> EthType i) AB.arbitrary_uint16;
@@ -49,6 +48,7 @@ let arbitrary_test, arbitrary_mod =
      ret_gen (IP4Dst(i,j)));
   ] @ shared),
   oneof ([
+    map_gen (fun s -> Location (Pipe s)) arbitrary_id;
     map_gen (fun i -> IP4Src(i,32l)) AB.arbitrary_uint32;
     map_gen (fun i -> IP4Dst(i,32l)) AB.arbitrary_uint32;
   ] @ shared))

--- a/test/NetKAT_Test.ml
+++ b/test/NetKAT_Test.ml
@@ -130,6 +130,15 @@ TEST "quickcheck failure on 10/16/2013" =
     (Seq (modSrc 0, Union (Filter (testSrc 2), modDst 2)))
     (Seq (modDst 2, modSrc 0))
 
+(* If a policy has a pipe location in a predicate, it should fail to compile. *)
+TEST "quickcheck failure on 8/25/2014" =
+  let b = "filter port = 0; (ethDst := fb:40:e5:6b:a8:f8; (ipSrc := 126.42.191.208 | ethTyp := 0x1464 | (filter ipDst = 155.173.129.111/22 | id); filter ipDst = 121.178.114.15/11 and port = __))" in
+  try
+    let _ = NetKAT_LocalCompiler.(to_table (of_policy 0L
+      (NetKAT_Parser.program NetKAT_Lexer.token (Lexing.from_string b)))) in
+    false
+  with _ -> true
+
 TEST "vlan" =
   let test_vlan_none = Test (Vlan 0xFFF) in
   let mod_vlan_none = Mod (Vlan 0xFFF) in


### PR DESCRIPTION
The way that the LocalCompiler generated flowtables when pipes appeared in predicates broke the NetKAT laws, specifically ka-plus-comm which you can see on build 706 on travis-ci. The LocalCompiler now fails if it encounters a pipe in a predicate, and the quickcheck arbitrary instance for predicates has been changed to not include pipe locations.
