### PR TITLE
mk_op: Use mk_{seq,union} operations for app composition

### DIFF
--- a/async/Async_NetKAT.ml
+++ b/async/Async_NetKAT.ml
@@ -120,7 +120,7 @@ let run (app : app) (t : Net.Topology.t ref) () : (recv * (event -> unit Deferre
   { pkt_out = recv.Raw_app.pkt_out; update = recv.Raw_app.update }, callback
 
 let union ?(how=`Parallel) (app1 : app) (app2 : app) : app =
-  Raw_app.combine ~how:how (fun x y -> Union(x, y)) app1 app2
+  Raw_app.combine ~how:how Optimize.mk_union app1 app2
 
 let seq (app1 : app) (app2 : app) : app =
   let open Raw_app in
@@ -131,7 +131,7 @@ let seq (app1 : app) (app2 : app) : app =
      * on a `PacketIn` event. *)
     raise (Sequence_error(app1.pipes, app2.pipes))
   end;
-  Raw_app.combine ~how:`Sequential (fun x y -> Seq(x, y)) app1 app2
+  Raw_app.combine ~how:`Sequential Optimize.mk_seq app1 app2
 
 let guard (pred : pred) (app : app) : app =
   seq (create_static (Filter pred)) app


### PR DESCRIPTION
These operators will eliminate extraneous policy fragments while performing composition, which will make the result easier to read at the very least.
