### PR TITLE
double compiler speed

### DIFF
--- a/lib/NetKAT_Types.ml
+++ b/lib/NetKAT_Types.ml
@@ -113,22 +113,33 @@ module Headers = struct
         } with sexp, fields
 
     let compare x y =
-      let g c a f =
-        if a <> 0 then a
-        else c (Field.get f x) (Field.get f y) in
-      Fields.fold
-        ~init:0
-        ~location:(g Location.compare)
-        ~ethSrc:(g EthSrc.compare)
-        ~ethDst:(g EthDst.compare)
-        ~vlan:(g Vlan.compare)
-        ~vlanPcp:(g VlanPcp.compare)
-        ~ethType:(g EthType.compare)
-        ~ipProto:(g IpProto.compare)
-        ~ipSrc:(g IpSrc.compare)
-        ~ipDst:(g IpDst.compare)
-        ~tcpSrcPort:(g TcpSrcPort.compare)
-        ~tcpDstPort:(g TcpDstPort.compare)
+      (* N.B. This is intentionally unrolled for performance purposes, as the
+       * comparison should short circuit as soon as possible. In light of that
+       * fact, it may be beneficial to reorder some of these checks in the
+       * future.
+       * *)
+      let c = Location.compare x.location y.location in
+      if c <> 0 then c else
+      let c = EthSrc.compare x.ethSrc y.ethSrc in
+      if c <> 0 then c else
+      let c = EthDst.compare x.ethDst y.ethDst in
+      if c <> 0 then c else
+      let c = Vlan.compare x.vlan y.vlan in
+      if c <> 0 then c else
+      let c = VlanPcp.compare x.vlanPcp y.vlanPcp in
+      if c <> 0 then c else
+      let c = EthType.compare x.ethType y.ethType in
+      if c <> 0 then c else
+      let c = IpProto.compare x.ipProto y.ipProto in
+      if c <> 0 then c else
+      let c = IpSrc.compare x.ipSrc y.ipSrc in
+      if c <> 0 then c else
+      let c = IpDst.compare x.ipDst y.ipDst in
+      if c <> 0 then c else
+      let c = TcpSrcPort.compare x.tcpSrcPort y.tcpSrcPort in
+      if c <> 0 then c else
+      let c = TcpDstPort.compare x.tcpDstPort y.tcpDstPort in
+      c
 
     let to_string ?init:(init="") ?sep:(sep="=") (x:t) : string =
       let g is_top to_string acc f =
@@ -225,9 +236,8 @@ module Int32TupleHeader = struct
   let equal x1 x2 = Ip.eq x1 x2
 
   let compare ((p,m):t) ((p',m'):t) : int =
-    if Pervasives.compare p p' = 0 then
-      Pervasives.compare m m'
-    else Pervasives.compare p p'
+    let c = Pervasives.compare p p' in
+    if c <> 0 then c else Pervasives.compare m m'
 
   let top = Ip.match_all
 


### PR DESCRIPTION
The compare function in the `Headers` module was not short-circuiting upon discovering a non-equal field. Adding the short-circuiting produces roughly a 2x speedup in the LocalCompiler. This result came from profiling the LocalCompiler using the policy that you can find below. The average (n=3) total running before the change was 11.647s, and the total running time after the change was 5.551s.

```
filter ethTyp = 0x806; (filter ethTyp = 0x806; port := host) |
filter not ethTyp = 0x806; (filter ethSrc = ff:ea:bb:ad:ab:ba; port := probe) |
filter not ethSrc = ff:ea:bb:ad:ab:ba;
(filter switch = 4;
 (filter ethDst = 00:00:00:00:00:05; port := 4 |
  (filter ethDst = 00:00:00:00:00:04; port := 4 |
   (filter ethDst = 00:00:00:00:00:03; port := 4 |
    (filter ethDst = 00:00:00:00:00:02; port := 4 |
     filter ethDst = 00:00:00:00:00:01; port := 4))) |
  (filter ethDst = ff:ff:ff:ff:ff:ff or
          not
          (ethDst = 00:00:00:00:00:05 or
           (ethDst = 00:00:00:00:00:04 or
            (ethDst = 00:00:00:00:00:03 or
             (ethDst = 00:00:00:00:00:02 or ethDst = 00:00:00:00:00:01))));
   (filter port = 4; (port := 3 | (port := 2 | port := 1)) |
    (filter port = 3; (port := 4 | (port := 2 | port := 1)) |
     (filter port = 2; (port := 4 | (port := 3 | port := 1)) |
      (filter port = 1; (port := 4 | (port := 3 | port := 2)) | drop)))) |
   filter not (ethSrc = 00:00:00:00:00:05) and
          (not (ethSrc = 00:00:00:00:00:04) and
           (not (ethSrc = 00:00:00:00:00:03) and
            (not (ethSrc = 00:00:00:00:00:02) and
             not (ethSrc = 00:00:00:00:00:01))));
   port := learn)) |
 (filter switch = 3;
  (filter ethDst = 00:00:00:00:00:04; port := 1 |
   (filter ethDst = 00:00:00:00:00:03; port := 4 |
    (filter ethDst = 00:00:00:00:00:02; port := 4 |
     filter ethDst = 00:00:00:00:00:01; port := 4)) |
   (filter ethDst = ff:ff:ff:ff:ff:ff or
           not
           (ethDst = 00:00:00:00:00:04 or
            (ethDst = 00:00:00:00:00:03 or
             (ethDst = 00:00:00:00:00:02 or ethDst = 00:00:00:00:00:01)));
    (filter port = 4; (port := 3 | (port := 2 | port := 1)) |
     (filter port = 3; (port := 4 | (port := 2 | port := 1)) |
      (filter port = 2; (port := 4 | (port := 3 | port := 1)) |
       (filter port = 1; (port := 4 | (port := 3 | port := 2)) | drop)))) |
    filter not (ethSrc = 00:00:00:00:00:04) and
           (not (ethSrc = 00:00:00:00:00:03) and
            (not (ethSrc = 00:00:00:00:00:02) and
             not (ethSrc = 00:00:00:00:00:01)));
    port := learn)) |
  (filter switch = 2;
   (filter ethDst = 00:00:00:00:00:04; port := 4 |
    (filter ethDst = 00:00:00:00:00:03; port := 3 |
     (filter ethDst = 00:00:00:00:00:02; port := 2 |
      filter ethDst = 00:00:00:00:00:01; port := 1)) |
    (filter ethDst = ff:ff:ff:ff:ff:ff or
            not
            (ethDst = 00:00:00:00:00:04 or
             (ethDst = 00:00:00:00:00:03 or
              (ethDst = 00:00:00:00:00:02 or ethDst = 00:00:00:00:00:01)));
     (filter port = 4; (port := 3 | (port := 2 | port := 1)) |
      (filter port = 3; (port := 4 | (port := 2 | port := 1)) |
       (filter port = 2; (port := 4 | (port := 3 | port := 1)) |
        (filter port = 1; (port := 4 | (port := 3 | port := 2)) | drop)))) |
     filter not (ethSrc = 00:00:00:00:00:04) and
            (not (ethSrc = 00:00:00:00:00:03) and
             (not (ethSrc = 00:00:00:00:00:02) and
              not (ethSrc = 00:00:00:00:00:01)));
     port := learn)) |
   (filter switch = 1;
    (filter ethDst = 00:00:00:00:00:04; port := 2 |
     (filter ethDst = 00:00:00:00:00:03; port := 1 |
      (filter ethDst = 00:00:00:00:00:02; port := 1 |
       filter ethDst = 00:00:00:00:00:01; port := 1)) |
     (filter ethDst = ff:ff:ff:ff:ff:ff or
             not
             (ethDst = 00:00:00:00:00:04 or
              (ethDst = 00:00:00:00:00:03 or
               (ethDst = 00:00:00:00:00:02 or ethDst = 00:00:00:00:00:01)));
      (filter port = 3; (port := 2 | port := 1) |
       (filter port = 2; (port := 3 | port := 1) |
        (filter port = 1; (port := 3 | port := 2) | drop))) |
      filter not (ethSrc = 00:00:00:00:00:04) and
             (not (ethSrc = 00:00:00:00:00:03) and
              (not (ethSrc = 00:00:00:00:00:02) and
               not (ethSrc = 00:00:00:00:00:01)));
      port := learn)) |
    drop))))
```
