### PR TITLE
compiler-api: simplify compiler API

### DIFF
--- a/lib/NetKAT_LocalCompiler.ml
+++ b/lib/NetKAT_LocalCompiler.ml
@@ -621,7 +621,7 @@ module Local = struct
     let open NetKAT_Types in
     Optimize.mk_seq (Filter (Pattern.to_netkat_pred p)) (Action.set_to_netkat a)
 
-  let to_netkat (t:t) : NetKAT_Types.policy =
+  let to_policy (t:t) : NetKAT_Types.policy =
     let open NetKAT_Types in
     Pattern.Map.fold t
       ~init:drop
@@ -1096,14 +1096,11 @@ end
 (* exports *)
 type t = RunTime.i
 
-let of_policy sw pol =
-  Local.of_policy (Optimize.specialize_policy sw pol)
-
-let to_netkat =
-  Local.to_netkat
-
 let compile sw p =
   RunTime.compile sw p
+
+let to_policy =
+  Local.to_policy
 
 let to_table ?(optimize_fall_through=false) t =
   Local_Optimize.remove_shadowed_rules

--- a/lib/NetKAT_LocalCompiler.mli
+++ b/lib/NetKAT_LocalCompiler.mli
@@ -2,8 +2,9 @@ open NetKAT_Types
 open SDN_Types
 
 type t 
-val of_policy : switchId -> policy -> t
-val to_netkat : t -> policy
+
 val compile : switchId -> policy -> t
-val to_table : ?optimize_fall_through:bool -> t -> flowTable
+
+val to_policy : t -> policy
+val to_table  : ?optimize_fall_through:bool -> t -> flowTable
 val to_string : t -> string

--- a/test/NetKAT_Test.ml
+++ b/test/NetKAT_Test.ml
@@ -6,7 +6,7 @@ open NetKAT_Pretty
 
 let test_compile lhs rhs =
   let tbl = NetKAT_LocalCompiler.compile 0L lhs in
-  let rhs' = NetKAT_LocalCompiler.to_netkat tbl in
+  let rhs' = NetKAT_LocalCompiler.to_policy tbl in
   if rhs' = rhs then
     true
   else
@@ -135,7 +135,7 @@ TEST "quickcheck failure on 10/16/2013" =
 (* TEST "quickcheck failure on 8/25/2014" = *)
 (*   let b = "filter port = 0; (ethDst := fb:40:e5:6b:a8:f8; (ipSrc := 126.42.191.208 | ethTyp := 0x1464 | (filter ipDst = 155.173.129.111/22 | id); filter ipDst = 121.178.114.15/11 and port = __))" in *)
 (*   try *)
-(*     let _ = NetKAT_LocalCompiler.(to_table (of_policy 0L *)
+(*     let _ = NetKAT_LocalCompiler.(to_table (compile 0L *)
 (*       (NetKAT_Parser.program NetKAT_Lexer.token (Lexing.from_string b)))) in *)
 (*     false *)
 (*   with _ -> true *)
@@ -145,7 +145,7 @@ TEST "quickcheck failure on 10/16/2013" =
 TEST "indeterminate pipe" =
   let b = "filter port = __; ethDst := fb:40:e5:6b:a8:f8" in
   try
-    let _ = NetKAT_LocalCompiler.(to_table (of_policy 0L
+    let _ = NetKAT_LocalCompiler.(to_table (compile 0L
       (NetKAT_Parser.program NetKAT_Lexer.token (Lexing.from_string b)))) in
     false
   with _ -> true
@@ -326,8 +326,8 @@ let compare_eval_output p q pkt =
 
 let compare_compiler_output p q pkt =
   PacketSet.compare
-    (Flowterp.Packet.eval pkt (NetKAT_LocalCompiler.(to_table (of_policy pkt.switch p))))
-    (Flowterp.Packet.eval pkt (NetKAT_LocalCompiler.(to_table (of_policy pkt.switch q))))
+    (Flowterp.Packet.eval pkt (NetKAT_LocalCompiler.(to_table (compile pkt.switch p))))
+    (Flowterp.Packet.eval pkt (NetKAT_LocalCompiler.(to_table (compile pkt.switch q))))
   = 0
 
 let check gen_fn compare_fn =
@@ -366,7 +366,7 @@ TEST "zero mask" =
     PacketSet.compare
       (NetKAT_Semantics.eval pkt (Optimize.specialize_policy pkt.switch pol))
       (Flowterp.Packet.eval pkt
-         (NetKAT_LocalCompiler.(to_table (of_policy pkt.switch pol)))) = 0 in
+         (NetKAT_LocalCompiler.(to_table (compile pkt.switch pol)))) = 0 in
   check gen_pkt prop_compile_ok
 
 TEST "semantics agree with flowtable" =
@@ -379,7 +379,7 @@ TEST "semantics agree with flowtable" =
     PacketSet.compare
       (NetKAT_Semantics.eval pkt (Optimize.specialize_policy pkt.switch p'))
       (Flowterp.Packet.eval pkt
-        (NetKAT_LocalCompiler.(to_table (of_policy pkt.switch p'))))
+        (NetKAT_LocalCompiler.(to_table (compile pkt.switch p'))))
     = 0 in
   check gen_pol_1 prop_compile_ok
 


### PR DESCRIPTION
There were two redundant functions in the module that did the same thing but had different definitions (`compile` and `of_policy`). In addition, renamed `to_netkat` to `to_policy`.
