### PR TITLE
probes: do not send any probe packets when discovery is disabled

### DIFF
--- a/async/discovery.ml
+++ b/async/discovery.ml
@@ -199,7 +199,10 @@ module Switch = struct
       | PortUp (sw_id, pt_id) ->
         Log.info ~tags "[topology.switch] ↑ { switch = %Lu; port = %lu }" sw_id pt_id;
         nib := add_port !nib (vertex_of_label !nib (Switch sw_id)) pt_id;
-        Pipe.write t.pkt_outs (to_out sw_id pt_id)
+        begin if enabled t
+          then Pipe.write t.pkt_outs (to_out sw_id pt_id)
+          else return ()
+        end
         >>| fun () -> [e]
       | PortDown (sw_id, pt_id) ->
         Log.info ~tags "[topology.switch] ↓ { switch = %Lu; port = %lu }" sw_id pt_id;


### PR DESCRIPTION
The code was sending a probe packet every time a new port came up on the a switch regardless of whether discovery was enabled. It now performs that check and only send the probe if it's enabled.
