### PR TITLE
nib: allow users to access the controller's nib

### DIFF
--- a/async/Async_NetKAT_Controller.ml
+++ b/async/Async_NetKAT_Controller.ml
@@ -676,6 +676,9 @@ let query ?(ignore_drops=true) pred t =
           Log.error ~tags "Unable to complete query: %s" (Sexp.to_string exn_))
   >>| fun () -> (!pkt, !byte)
 
+let nib t =
+  !(t.nib)
+
 let enable_discovery t =
   Discovery.start t.dis
 

--- a/async/Async_NetKAT_Controller.mli
+++ b/async/Async_NetKAT_Controller.mli
@@ -1,6 +1,8 @@
 open Core.Std
 open Async.Std
 
+open Async_NetKAT
+
 type t
 
 (** [start pol ()] starts an OpenFlow 1.0 controller that is capable of
@@ -8,7 +10,7 @@ type t
 
     By default, topology discovery is disabled when the controller starts. *)
 val start
-  :  Async_NetKAT.Policy.t
+  :  Policy.t
   -> ?port:int
   -> ?update:[`BestEffort | `PerPacketConsistent ]
   -> ?policy_queue_size:int
@@ -21,6 +23,13 @@ val start
     that match the predicate but have a _drop_ action. To include flows with
     drop actions in the results, use [query ~ingore_drops:false pred t]. *)
 val query : ?ignore_drops:bool -> NetKAT_Types.pred -> t -> (Int64.t * Int64.t) Deferred.t
+
+(** [nib t] return the in-memory representation of the controller's network
+    information base. This is an immutable structure that will remain consistent
+    with the controller's representation for as long as the application does not
+    block. After that, topology events may have been received and integrated
+    into the controller's NIB. *)
+val nib : t -> Net.Topology.t
 
 (** [enable_discovery t] enables detection of hosts on the network as well as
     links between switches. For host discovery, the controller will intercept a


### PR DESCRIPTION
Application event handlers already have access to it. However, it's necessary for monitoring and diagnostics for the application that the controller's embedded in to access this information as well.
