### PR TITLE
discovery: report PortDown events

### DIFF
--- a/async/discovery.ml
+++ b/async/discovery.ml
@@ -222,7 +222,7 @@ module Switch = struct
               | Host _ -> []
             end
         end in
-        return es
+        return (es @ [e])
       | LinkUp ((sw1, pt1), (sw2, pt2)) ->
         assert false
       | LinkDown ((sw1, pt1), (sw2, pt2)) ->


### PR DESCRIPTION
When discovery was enabled, the code was incorrectly swallowing `PortDown` events and just reporting any `LinkDown` events related to that port. The code now reports the `LinkDown` event, followed by the `PortDown` event.
