### PR TITLE
mac: identify controller traffic by destination MAC

### DIFF
--- a/async/discovery.ml
+++ b/async/discovery.ml
@@ -237,7 +237,7 @@ module Switch = struct
     let open Async_NetKAT in
     let open NetKAT_Types in
     let flip_ctl, flip_app =
-      Flip.create (And(Test(EthType Probe.protocol), (Test(EthSrc Probe.mac))))
+      Flip.create ((Test(EthSrc Probe.mac)))
     in
     let r_pkt_outs, pkt_outs = Pipe.create () in
     let edge_app = Raw.create [] (fun nib send () ->


### PR DESCRIPTION
Do not check the ethernet type to identify probes from the controller. Any packet with the controller destination should be forwarded to the controller.
