### PR TITLE
Update to compile against the Core port of ocaml-topology

### DIFF
--- a/async/Async_NetKAT.ml
+++ b/async/Async_NetKAT.ml
@@ -7,10 +7,10 @@ exception Assertion_failed of string
 
 type node =
     | Switch of SDN_Types.switchId
-    | Host of Packet.dlAddr * Packet.nwAddr
+    | Host of Packet.dlAddr * Packet.nwAddr with sexp
 
 module Node = struct
-  type t = node
+  type t = node with sexp
 
   let compare = Pervasives.compare
 
@@ -28,7 +28,7 @@ module Node = struct
 end
 
 module Link = struct
-  type t = unit
+  type t = unit with sexp
 
   let compare = Pervasives.compare
 

--- a/async/Async_NetKAT_Controller.ml
+++ b/async/Async_NetKAT_Controller.ml
@@ -211,8 +211,8 @@ let to_event (w_out : (switchId * SDN_Types.pktOut) Pipe.Writer.t)
       let open Net.Topology in
       let v  = vertex_of_label !(t.nib) (Async_NetKAT.Switch c_id) in
       let ps = vertex_to_ports !(t.nib) v in
-      return (PortSet.fold (fun p acc -> (PortDown(c_id, p))::acc)
-        ps [SwitchDown c_id])
+      return (PortSet.fold ps ~init:[SwitchDown c_id]
+		~f:(fun acc p -> (PortDown(c_id, p))::acc))
     | `Message (c_id, (xid, msg)) ->
       let open OpenFlow0x01.Message in
       begin match msg with
@@ -324,7 +324,7 @@ module PerPacketConsistent = struct
     List.fold_right actions ~init:[] ~f:(fun action acc ->
       begin match action with
       | Output (Physical   pt) ->
-        if not (Net.Topology.PortSet.mem pt internal_ports) then
+        if not (Net.Topology.PortSet.mem internal_ports pt) then
           [Modify (SetVlan None)]
         else
           [Modify (SetVlan (Some ver))]
@@ -338,7 +338,7 @@ module PerPacketConsistent = struct
     let vlan_none = 65535 in
     List.filter_map table ~f:(fun flow ->
       begin match flow.pattern.Pattern.inPort with
-      | Some pt when Net.Topology.PortSet.mem pt internal_ports ->
+      | Some pt when Net.Topology.PortSet.mem internal_ports pt ->
         None
       | _ ->
         Some { flow with

--- a/async/learning.ml
+++ b/async/learning.ml
@@ -30,8 +30,8 @@ let create () =
   let default = Mod(Location(Pipe "learn")) in
   let drop = Filter False in
 
-  let all_ports ps = Net.Topology.PortSet.fold (fun p acc ->
-    mk_union (Mod(Location(Physical p))) acc) ps drop
+  let all_ports ps = Net.Topology.PortSet.fold ps ~init:drop ~f:(fun acc p ->
+    mk_union (Mod(Location(Physical p))) acc)
   in
 
   let gen_pol nib =
@@ -48,11 +48,10 @@ let create () =
         let open Net.Topology in
         let v  = vertex_of_label nib (Async_NetKAT.Switch switch_id) in
         let ps = vertex_to_ports nib v in
-        let ports = PortSet.fold (fun p acc ->
+        let ports = PortSet.fold ps ~init:drop ~f:(fun acc p ->
             Union(Seq(Filter(Test(Location(Physical p))),
-                      all_ports (PortSet.remove p ps)),
+                      all_ports (PortSet.remove ps p)),
                   acc))
-          ps drop
         in
         Seq(Filter(Or(Test(EthDst 0xffffffffffffL), Neg(!known_pred))), ports)
       in


### PR DESCRIPTION
`ocaml-topology` has a port to Jane Street's Core for easier use with Merlin. This changes function calls and types in the Frenetic codebase to compile properly against that version.
