### PR TITLE
New cache-clearing policy

### DIFF
--- a/async/Async_NetKAT_Controller.ml
+++ b/async/Async_NetKAT_Controller.ml
@@ -574,7 +574,8 @@ let start app ?(port=6633) ?(update=`BestEffort) ?(policy_queue_size=0) () =
         Log.info ~tags "[policy] Processing queue of size %d" len;
 
       let old = t.repr in
-      t.repr   <- LC.compile (Queue.get q (len - 1));
+      let cache = `Preserve old in
+      t.repr   <- LC.compile ~cache (Queue.get q (len - 1));
 
       if LC.equal old t.repr then begin
         Log.debug ~tags "[policy] Skipping identical policy update";

--- a/lib/NetKAT_LocalCompiler.ml
+++ b/lib/NetKAT_LocalCompiler.ml
@@ -1,7 +1,6 @@
 open Core.Std
 open NetKAT_FDD
 
-
 module Field = NetKAT_FDD.Field
 exception Non_local = NetKAT_FDD.Non_local
 
@@ -169,11 +168,18 @@ end
 
 include Repr
 
-let clear_cache () = T.clear_cache ()
+type cache
+  = [ `Keep
+    | `Empty
+    | `Preserve of t ]
 
-let compile ?(order=`Heuristic) ?(clear_cache=true) pol =
-  (if clear_cache then
-     T.clear_cache ());
+let clear_cache () = T.clear_cache Int.Set.empty
+
+let compile ?(order=`Heuristic) ?(cache=`Empty) pol =
+  (match cache with
+   | `Keep -> ()
+   | `Empty -> T.clear_cache Int.Set.empty
+   | `Preserve fdd -> T.clear_cache (T.refs fdd));
   (match order with
    | `Heuristic -> Field.auto_order pol
    | `Default -> Field.set_order Field.all_fields

--- a/lib/NetKAT_LocalCompiler.mli
+++ b/lib/NetKAT_LocalCompiler.mli
@@ -1,3 +1,4 @@
+open Core.Std
 open NetKAT_Types
 open NetKAT_Semantics
 
@@ -30,8 +31,14 @@ type order
     | `Static of Field.t list
     | `Heuristic ]
 
+
 type t
 (** The type of the intermediate compiler representation. *)
+
+type cache
+  = [ `Keep
+    | `Empty
+    | `Preserve of t ]
 
 (** {2 Compilation} *)
 
@@ -40,7 +47,7 @@ exception Non_local
     [Link] term in it. [Link] terms are currently not supported by this
     compiler. *)
 
-val compile : ?order:order -> ?clear_cache:bool -> policy -> t
+val compile : ?order:order -> ?cache:cache -> policy -> t
 (** [compile p] returns the intermediate representation of the policy [p].
     You can generate a flowtable from [t] by passing it to the {!to_table}
     function below.
@@ -48,7 +55,7 @@ val compile : ?order:order -> ?clear_cache:bool -> policy -> t
     The optional [order] flag determines the variable order. If unset,
     it uses a static default ordering.
 
-    The optional [clear_cache] flag determines if the cache should be cleared
+    The optional [cache] flag determines if the cache should be cleared
     before compilation. By default, the cache is cleared.
  *)
 
@@ -134,7 +141,5 @@ val eval_pipes
     first component is a list of packets and corresponding pipe location, whose
     second is a list of packets and corresponding query location, and whose
     third is a list of packets that are at physical locations. *)
-
-val clear_cache : unit -> unit
 
 val to_dotfile : t -> string -> unit

--- a/lib/NetKAT_Vlr.mli
+++ b/lib/NetKAT_Vlr.mli
@@ -1,3 +1,5 @@
+open Core.Std
+
 (** The signature for a type that can be compared and hashed *)
 module type HashCmp = sig
   type t
@@ -191,7 +193,7 @@ module Make(V:HashCmp)(L:Lattice)(R:Result) : sig
   val to_string : t -> string
   (** [to_string t] returns a string representation of the diagram. *)
 
-  val clear_cache : unit -> unit
+  val clear_cache : preserve:Int.Set.t -> unit
   (** [clear_cache ()] clears the internal cache of diagrams. *)
 
   val compressed_size : t -> int
@@ -203,6 +205,8 @@ module Make(V:HashCmp)(L:Lattice)(R:Result) : sig
       using Graphviz or any other program that supports the DOT language. *)
 
   val map_values : (r -> r) -> t -> t
+
+  val refs : t -> Core.Std.Int.Set.t
 
 end
 

--- a/test/FDD_Cache.ml
+++ b/test/FDD_Cache.ml
@@ -1,0 +1,27 @@
+open OUnitHack
+open NetKAT_Types
+open NetKAT_LocalCompiler
+
+TEST "clearing cache fails" =
+  let a = Test (IPProto 1) in
+  let b = Test (EthType 0x800) in
+  let fdd1 = compile (Filter a) in
+  let fdd2 = compile ~cache:`Empty (Filter b) in
+  try
+    seq fdd1 fdd2 != compile ~cache:`Keep (Filter (And (a, b)))
+  with
+    Not_found -> true
+
+TEST "keeping cache works" =
+  let a = Test (IPProto 1) in
+  let b = Test (EthType 0x800) in
+  let fdd1 = compile (Filter a) in
+  let fdd2 = compile ~cache:`Keep (Filter b) in
+  seq fdd1 fdd2 = compile ~cache:`Keep (Filter (And (a, b)))
+
+TEST "keeping reachable nodes in cache works" =
+  let a = Test (IPProto 1) in
+  let b = Test (EthType 0x800) in
+  let fdd1 = compile (Filter a) in
+  let fdd2 = compile ~cache:(`Preserve fdd1) (Filter b) in
+  seq fdd1 fdd2 = compile ~cache:`Keep (Filter (And (a, b)))

--- a/test/Test.ml
+++ b/test/Test.ml
@@ -1,5 +1,6 @@
 (* Write tests in independent modules, then just include them here to run them
  *)
+open FDD_Cache
 open FlowTable_Generation
 open NetKAT_Test
 open NetKAT_Pretty_Tests


### PR DESCRIPTION
In addition to completely preserving and clearing the cache, the
local compiler can now clear everything except an the data for
an existing FDD.

This fixes an issue with the controller, where FDD-operations are
used to compare the new and old FDD after compile is called.
Clearing the cache completely invalidates the old FDD. Using
the new `Preserve option, we can clear all the auxiliary data
used to create the old FDD but keep it intact.