### PR TITLE
Readded setup.data line to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ setup.ml: _oasis
 	sed -i 's/archive(syntax, preprocessor) = "syntax.cma"/archive(syntax, preprocessor) = "ulexing.cma syntax.cma"/g' lib/META
 	sed -i 's/archive(syntax, preprocessor, native) = "syntax.cmxa"/archive(syntax, preprocessor, native) = "ulexing.cmxa syntax.cmxa"/g' lib/META
 
+setup.data: setup.ml
+	ocaml setup.ml -configure $(ASYNC) $(TESTS)
+
 build: setup.data setup.ml
 	ocaml setup.ml -build -j $(J)
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ setup.ml: _oasis
 	sed -i 's/archive(syntax, preprocessor, native) = "syntax.cmxa"/archive(syntax, preprocessor, native) = "ulexing.cmxa syntax.cmxa"/g' lib/META
 
 setup.data: setup.ml
-	ocaml setup.ml -configure $(ASYNC) $(TESTS)
+	./configure
 
 build: setup.data setup.ml
 	ocaml setup.ml -build -j $(J)


### PR DESCRIPTION
For some reason the line to generate `setup.data` got dropped from the Makefile. This adds it back.