### PR TITLE
Cherry-picking Joe's edits

### DIFF
--- a/lang/python/frenetic/examples/discovery.py
+++ b/lang/python/frenetic/examples/discovery.py
@@ -1,0 +1,93 @@
+import frenetic
+import networkx
+import base64
+import binascii
+from ryu.lib.packet import packet
+from ryu.lib.packet import ethernet
+from ryu.lib.packet import arp
+from frenetic.syntax import *
+from tornado.ioloop import PeriodicCallback
+
+class SwitchRef(object):
+  
+  def __init__(self, id, ports):
+    self.id = id
+    self.ports = ports
+
+def flood_switch_policy(switch):
+  assert isinstance(switch, SwitchRef)
+  pol = False
+  for src in switch.ports:
+    test = Filter(Test(Location(Physical(src))))
+    actions = False
+    for dst in switch.ports:
+      if src == dst:
+        continue
+      action = test >> Mod(Location(Physical(dst)))
+      if not actions:
+        actions = action
+      else:
+        actions = action | actions
+    if not pol:
+      pol = actions
+    else:
+      pol = actions | pol
+  return Filter(Test(Switch(switch.id))) >> pol
+
+class Discovery(frenetic.App):
+
+  def __init__(self, state):
+    frenetic.App.__init__(self)
+    self.state = state
+    self.update(self.global_policy())
+    PeriodicCallback(self.run_probe, 10000).start()
+
+  def run_probe(self):
+    print "Running probes!"
+    for switch in self.state.switches.values():
+      switch_id = switch.id
+      pkt = packet.Packet()
+      pkt.add_protocol(ethernet.ethernet(ethertype=0x100, src=('00:00:00:00:00:0' + str(switch_id))))
+#      pkt.add_protocol(arp.arp(proto=0x100))
+      pkt.serialize()
+      payload = NotBuffered(binascii.a2b_base64(binascii.b2a_base64(pkt.data)))
+      actions = [Output(Physical(port)) for port in switch.ports]
+      self.pkt_out(switch_id, payload, actions)
+
+  def global_policy(self):
+    probe_traffic = Filter(Test(EthType(0x100))) >> Mod(Location(Pipe("http")))
+    pols = Union([flood_switch_policy(ps) for ps in self.state.switches.values()])
+    return pols | probe_traffic
+
+  def switch_up(self, switch_id, ports):
+    print "switch_up(%s, %s)" % (switch_id, ports)
+    self.state.switches[switch_id] = SwitchRef(switch_id, ports)
+    self.state.network.add_node(switch_id)
+    self.update(self.global_policy())
+    
+
+  def switch_down(self, switch_id):
+    print "switch_down(%s)" % switch_id
+    del self.state.switches[switch_id]
+    self.state.network.remove_node(switch_id)
+    self.update(self.global_policy())
+
+  def packet_in(self, switch_id, port_id, payload):
+    print "packet_in(%s,%s,payload)" % (switch_id, port_id)
+
+
+class State(object):
+
+  def __init__(self):
+    self.network = networkx.Graph()
+    self.switches = {}
+
+def packet_in(self, switch_id, port_id, payload):
+  print "Packet in!"
+
+def main(version):
+  app = Discovery(State())
+  app.start_event_loop()
+
+if __name__ == '__main__':
+  main(1)

--- a/lang/python/frenetic/examples/discovery.py
+++ b/lang/python/frenetic/examples/discovery.py
@@ -17,6 +17,7 @@ def port_node(switch_id, port):
 class ProbeData(packet_base.PacketBase):
 
   PROBOCOL = 0x808
+  NO_RESPONSE_THRESHOLD = 5
   _PACK_STR = '!LH'
   _MIN_LEN = struct.calcsize(_PACK_STR)
   _TYPE = {
@@ -36,6 +37,14 @@ class ProbeData(packet_base.PacketBase):
 
   def serialize(self, payload, prev):
       return struct.pack(ProbeData._PACK_STR, self.src_switch, self.src_port)
+
+  def __eq__(self, other):
+    return (isinstance(other, self.__class__) and
+            self.src_switch == other.src_switch and
+            self.src_port == other.src_port)
+
+  def __hash__(self):
+    return self.src_switch*29 + self.src_port*37
 
 ProbeData.register_packet_type(ProbeData, ProbeData.PROBOCOL)
 
@@ -75,8 +84,28 @@ class Discovery(frenetic.App):
     # Every 10 seconds send out probes on ports we don't know about
     PeriodicCallback(self.run_probe, 10000).start()
 
+  def check_host_edge(self, probe_data):
+    # If we have not met the probe threshold don't accept any edges
+    if self.state.probes_sent[probe_data] < ProbeData.NO_RESPONSE_THRESHOLD:
+      return False
+    # If we are past the threshold but no tentative edge exists keep probing
+    if not (probe_data in self.state.tentative_edge):
+      return False
+    # Else we should solidify the edge and stop probing
+    host_ip = self.state.tentative_edge[probe_data]
+    del self.state.tentative_edge[probe_data]
+    print "Permanent edge: (%s, %s) to %s" % (probe_data.src_switch, probe_data.src_port, host_ip)
+    self.update(self.global_policy())
+    return True
+
   def run_probe(self):
+    to_remove = set()
     for probe_data in self.state.probes:
+      # Check if this probe is a host edge
+      if self.check_host_edge(probe_data):
+        to_remove.add(probe_data)
+        continue
+
       # Build a PROBOCOL packet and send it out
       print "Sending probe: (%s, %s)" % (probe_data.src_switch, probe_data.src_port)
       pkt = packet.Packet()
@@ -86,12 +115,23 @@ class Discovery(frenetic.App):
       payload = NotBuffered(binascii.a2b_base64(binascii.b2a_base64(pkt.data)))
       actions = [Output(Physical(probe_data.src_port))]
       self.pkt_out(probe_data.src_switch, payload, actions)
+      self.state.probes_sent[probe_data] = self.state.probes_sent[probe_data] + 1
+
+    # Cleanup any host edges we discovered
+    for probe_data in to_remove:
+      self.state.probes.discard(probe_data)
+
+  def shortest_path(self, src_host, dst_host):
+    if not networkx.has_path(self.state.network, src_host, dst_host):
+      return Filter(Test(IP4Src(src_host)) and Test(IP4Dst(dst_host)))
 
   def global_policy(self):
     # All PROBOCOL traffic is sent to the controller, otherwise flood
     probe_traffic = Filter(Test(EthType(ProbeData.PROBOCOL))) >> Mod(Location(Pipe("http")))
-    pols = Filter(Not(Test(EthType(ProbeData.PROBOCOL)))) >> Union([flood_switch_policy(ps) for ps in self.state.switches.values()])
-    return pols | probe_traffic
+    sniff_arp = Filter(Test(EthType(0x806))) >> Mod(Location(Pipe("http")))
+    flood = Filter(Not(Test(EthType(ProbeData.PROBOCOL)))) >> Union([flood_switch_policy(ps) for ps in self.state.switches.values()])
+    refining_filter = Filter(Id())
+    return probe_traffic | sniff_arp | (refining_filter >> flood)
 
   def add_switch(self, switch_ref):
     # Add a node for a switch and each of its ports.
@@ -103,7 +143,6 @@ class Discovery(frenetic.App):
       node = port_node(switch_ref.id, port)
       self.state.network.add_node(node)
       self.state.network.add_edge(node, switch_ref.id)
-      self.state.network.add_edge(switch_ref.id, node)
 
   def remove_switch(self, switch_ref):
     # Remove a switch and each of its ports from the graph
@@ -114,11 +153,15 @@ class Discovery(frenetic.App):
 
   def create_probes(self, switch_ref):
     for port in switch_ref.ports:
-      self.state.probes.add((switch_ref.id, port))
-
+      probe_data = ProbeData(switch_ref.id, port)
+      self.state.probes.add(probe_data)
+      self.state.probes_sent[probe_data] = 0
+        
   def discard_probes(self, switch_ref):
     for port in switch_ref.ports:
-      self.state.probes.discard((switch_ref.id, port))
+      probe_data = ProbeData(switch_ref.id, port)
+      self.state.probes.discard(probe_data)
+      del self.state.probes_sent[probe_data]
 
   def switch_up(self, switch_id, ports):
     # When a switch comes up, add it to the network and create
@@ -128,7 +171,7 @@ class Discovery(frenetic.App):
     self.add_switch(self.state.switches[switch_id])
     self.create_probes(self.state.switches[switch_id])
     self.update(self.global_policy())
-    
+
   def switch_down(self, switch_id):
     # When a switch goes down, remove any unresolved probes and remove 
     # it from the network graph
@@ -138,22 +181,47 @@ class Discovery(frenetic.App):
     del self.state.switches[switch_id]
     self.update(self.global_policy())
 
+  def remove_tentative_edge(self, probe_data):
+    if(probe_data in self.state.tentative_edge):
+      host_ip = self.state.tentative_edge[probe_data]
+      node = port_node(probe_data.src_switch, probe_data.src_port)
+      del self.state.tentative_edge[probe_data]
+      self.state.network.remove_edge(node, host_ip)
+      print "Removed tentative edge: (%s, %s) to %s" % (probe_data.src_switch, probe_data.src_port, host_ip)
+
   def handle_probe(self, dst_switch, dst_port, src_switch, src_port):
     # When a probe is received, add edges based on where it traveled
     print "Probe received from (%s, %s) to (%s, %s)" % (src_switch, src_port, dst_switch, dst_port)
     node0 = port_node(dst_switch, dst_port)
     node1 = port_node(src_switch, src_port)
     self.state.network.add_edge(node0, node1)
-    self.state.network.add_edge(node1, node0)
-    self.state.probes.discard((dst_switch, dst_port))
-    self.state.probes.discard((src_switch, src_port))
-
+    self.state.probes.discard(ProbeData(dst_switch, dst_port))
+    self.state.probes.discard(ProbeData(src_switch, src_port))
+    self.remove_tentative_edge(ProbeData(src_switch, src_port))
+    self.remove_tentative_edge(ProbeData(dst_switch, dst_port))
+      
   def packet_in(self, switch_id, port_id, payload):
     pkt = packet.Packet(array.array('b', payload.data))
     p = get(pkt, 'ethernet')
     if (p.ethertype == ProbeData.PROBOCOL):
       probe_data = get(pkt, 'ProbeData')
       self.handle_probe(switch_id, port_id, probe_data.src_switch, probe_data.src_port)
+    if (p.ethertype == 0x806):
+# arp(dst_ip='10.0.0.2',dst_mac='00:00:00:00:00:02',hlen=6,hwtype=1,opcode=2,plen=4,proto=2048,src_ip='10.0.0.1',src_mac='00:00:00:00:00:01')
+      arp = get(pkt, 'arp')
+      self.state.hosts.add(arp.src_ip)
+      self.state.hosts.add(arp.dst_ip)
+      self.state.network.add_node(arp.src_ip)
+      self.state.network.add_node(arp.dst_ip)
+
+      if(ProbeData(switch_id, port_id) in self.state.probes and
+         ProbeData(switch_id, port_id) not in self.state.tentative_edge):
+        print "Tentative edge found from (%s, %s) to %s" % (switch_id, port_id, arp.src_ip)
+        # This switch / ports probe has not been seen
+        # We will tentatively assume it is connected to the src host
+        node = port_node(switch_id, port_id)
+        self.state.tentative_edge[ProbeData(switch_id, port_id)] = arp.src_ip
+        self.state.network.add_edge(node, arp.src_ip)
 
 
 class State(object):
@@ -162,6 +230,9 @@ class State(object):
     self.network = networkx.Graph()
     self.switches = {}
     self.probes = set()
+    self.hosts = set()
+    self.probes_sent = {}
+    self.tentative_edge = {}
 
 def packet_in(self, switch_id, port_id, payload):
   print "Packet in!"

--- a/lang/python/frenetic/examples/discovery.py
+++ b/lang/python/frenetic/examples/discovery.py
@@ -3,26 +3,20 @@ from ryu.lib.packet import packet, packet_base, ethernet, arp
 from frenetic.syntax import *
 from tornado.ioloop import PeriodicCallback
 
-# Probe protocol
-probocol = 0x808
-
 def get(pkt,protocol):
     for p in pkt:
         if p.protocol_name == protocol:
             return p
 
-def to_str(switch_id, port):
-  return str(switch_id) + ':' + str(port)
-
-def from_str(src_string):
-  strs = src_string.split(':')
-  return (int(strs[0]), int(strs[1]))
-
+# Helper function to ensure the string is always the same
+# when creating a node that is a port
 def port_node(switch_id, port):
   return str(switch_id) + ':' + str(port)
 
+# Packet to be encoded for sending Probes over the probocol
 class ProbeData(packet_base.PacketBase):
 
+  PROBOCOL = 0x808
   _PACK_STR = '!LH'
   _MIN_LEN = struct.calcsize(_PACK_STR)
   _TYPE = {
@@ -38,19 +32,20 @@ class ProbeData(packet_base.PacketBase):
   @classmethod
   def parser(cls, buf):
       (src_switch, src_port) = struct.unpack_from(cls._PACK_STR, buf)
-      return cls(src_switch, src_port), cls._TYPES.get(probocol), buf[ProbeData._MIN_LEN:]
+      return cls(src_switch, src_port), cls._TYPES.get(cls.PROBOCOL), buf[ProbeData._MIN_LEN:]
 
   def serialize(self, payload, prev):
       return struct.pack(ProbeData._PACK_STR, self.src_switch, self.src_port)
 
-ProbeData.register_packet_type(ProbeData, probocol)
+ProbeData.register_packet_type(ProbeData, ProbeData.PROBOCOL)
 
+# Helper class to store switch information
 class SwitchRef(object):
-  
   def __init__(self, id, ports):
     self.id = id
     self.ports = ports
 
+# Create a policy that given a SwitchRef, floods all input to its ports
 def flood_switch_policy(switch):
   assert isinstance(switch, SwitchRef)
   pol = False
@@ -77,27 +72,32 @@ class Discovery(frenetic.App):
     frenetic.App.__init__(self)
     self.state = state
     self.update(self.global_policy())
+    # Every 10 seconds send out probes on ports we don't know about
     PeriodicCallback(self.run_probe, 10000).start()
 
   def run_probe(self):
-    for probe in self.state.probes:
-      switch_id = probe[0]
-      port = probe[1]
-      print "Sending probe: (%s, %s)" % (switch_id, port)
+    for probe_data in self.state.probes:
+      # Build a PROBOCOL packet and send it out
+      print "Sending probe: (%s, %s)" % (probe_data.src_switch, probe_data.src_port)
       pkt = packet.Packet()
-      pkt.add_protocol(ethernet.ethernet(ethertype=probocol))
-      pkt.add_protocol(ProbeData(switch_id, port))
+      pkt.add_protocol(ethernet.ethernet(ethertype=ProbeData.PROBOCOL))
+      pkt.add_protocol(probe_data)
       pkt.serialize()
       payload = NotBuffered(binascii.a2b_base64(binascii.b2a_base64(pkt.data)))
-      actions = [Output(Physical(port))]
-      self.pkt_out(switch_id, payload, actions)
+      actions = [Output(Physical(probe_data.src_port))]
+      self.pkt_out(probe_data.src_switch, payload, actions)
 
   def global_policy(self):
-    probe_traffic = Filter(Test(EthType(probocol))) >> Mod(Location(Pipe("http")))
-    pols = Filter(Not(Test(EthType(probocol)))) >> Union([flood_switch_policy(ps) for ps in self.state.switches.values()])
+    # All PROBOCOL traffic is sent to the controller, otherwise flood
+    probe_traffic = Filter(Test(EthType(ProbeData.PROBOCOL))) >> Mod(Location(Pipe("http")))
+    pols = Filter(Not(Test(EthType(ProbeData.PROBOCOL)))) >> Union([flood_switch_policy(ps) for ps in self.state.switches.values()])
     return pols | probe_traffic
 
   def add_switch(self, switch_ref):
+    # Add a node for a switch and each of its ports.
+    # Switch Nodes are integer values
+    # Port Nodes are strings '<switch>:<port>' for example switch 3 port 2 would be
+    # the string '3:2'
     self.state.network.add_node(switch_ref.id)
     for port in switch_ref.ports:
       node = port_node(switch_ref.id, port)
@@ -106,6 +106,7 @@ class Discovery(frenetic.App):
       self.state.network.add_edge(switch_ref.id, node)
 
   def remove_switch(self, switch_ref):
+    # Remove a switch and each of its ports from the graph
     self.state.network.remove_node(switch_ref.id)
     for port in switch_ref.ports:
       node = port_node(switch_ref.id, port)
@@ -120,6 +121,8 @@ class Discovery(frenetic.App):
       self.state.probes.discard((switch_ref.id, port))
 
   def switch_up(self, switch_id, ports):
+    # When a switch comes up, add it to the network and create
+    # probes for each of its ports
     print "switch_up(%s, %s)" % (switch_id, ports)
     self.state.switches[switch_id] = SwitchRef(switch_id, ports)
     self.add_switch(self.state.switches[switch_id])
@@ -127,6 +130,8 @@ class Discovery(frenetic.App):
     self.update(self.global_policy())
     
   def switch_down(self, switch_id):
+    # When a switch goes down, remove any unresolved probes and remove 
+    # it from the network graph
     print "switch_down(%s)" % switch_id
     self.discard_probes(self.state.switches[switch_id])
     self.remove_switch(self.state.switches[switch_id])
@@ -134,6 +139,7 @@ class Discovery(frenetic.App):
     self.update(self.global_policy())
 
   def handle_probe(self, dst_switch, dst_port, src_switch, src_port):
+    # When a probe is received, add edges based on where it traveled
     print "Probe received from (%s, %s) to (%s, %s)" % (src_switch, src_port, dst_switch, dst_port)
     node0 = port_node(dst_switch, dst_port)
     node1 = port_node(src_switch, src_port)
@@ -145,7 +151,7 @@ class Discovery(frenetic.App):
   def packet_in(self, switch_id, port_id, payload):
     pkt = packet.Packet(array.array('b', payload.data))
     p = get(pkt, 'ethernet')
-    if (p.ethertype == probocol):
+    if (p.ethertype == ProbeData.PROBOCOL):
       probe_data = get(pkt, 'ProbeData')
       self.handle_probe(switch_id, port_id, probe_data.src_switch, probe_data.src_port)
 

--- a/lang/python/frenetic/examples/discovery.py
+++ b/lang/python/frenetic/examples/discovery.py
@@ -1,12 +1,29 @@
-import frenetic
-import networkx
-import base64
-import binascii
+import frenetic, networkx, base64, binascii, array
 from ryu.lib.packet import packet
 from ryu.lib.packet import ethernet
 from ryu.lib.packet import arp
 from frenetic.syntax import *
 from tornado.ioloop import PeriodicCallback
+
+# Probe protocol
+probocol = 0x808
+
+def get(pkt,protocol):
+    for p in pkt:
+        if p.protocol_name == protocol:
+            return p
+
+def to_str(switch_id, port):
+  #TODO(jcollard): really hacky
+  return '00:00:00:00:0' + str(switch_id) + ':0' + str(port)
+
+def from_str(src_string):
+  #TODO(jcollard): really hacky
+  strs = src_string.split(':')
+  return (int(strs[4]), int(strs[5]))
+
+def port_node(switch_id, port):
+  return str(switch_id) + ':' + str(port)
 
 class SwitchRef(object):
   
@@ -43,37 +60,70 @@ class Discovery(frenetic.App):
     PeriodicCallback(self.run_probe, 10000).start()
 
   def run_probe(self):
-    print "Running probes!"
-    for switch in self.state.switches.values():
-      switch_id = switch.id
+    for probe in self.state.probes:
+      switch_id = probe[0]
+      port = probe[1]
+      print "Sending probe: (%s, %s)" % (switch_id, port)
       pkt = packet.Packet()
-      pkt.add_protocol(ethernet.ethernet(ethertype=0x100, src=('00:00:00:00:00:0' + str(switch_id))))
-#      pkt.add_protocol(arp.arp(proto=0x100))
+      pkt.add_protocol(ethernet.ethernet(ethertype=probocol, src=to_str(switch_id, port)))
       pkt.serialize()
       payload = NotBuffered(binascii.a2b_base64(binascii.b2a_base64(pkt.data)))
-      actions = [Output(Physical(port)) for port in switch.ports]
+      actions = [Output(Physical(port))]
       self.pkt_out(switch_id, payload, actions)
 
   def global_policy(self):
-    probe_traffic = Filter(Test(EthType(0x100))) >> Mod(Location(Pipe("http")))
+    probe_traffic = Filter(Test(EthType(probocol))) >> Mod(Location(Pipe("http")))
     pols = Union([flood_switch_policy(ps) for ps in self.state.switches.values()])
     return pols | probe_traffic
+
+  def add_switch(self, switch_ref):
+    self.state.network.add_node(switch_ref.id)
+    for port in switch_ref.ports:
+      node = port_node(switch_ref.id, port)
+      self.state.network.add_node(node)
+      self.state.network.add_edge(node, switch_ref.id)
+      self.state.network.add_edge(switch_ref.id, node)
+
+  def remove_switch(self, switch_ref):
+    self.state.network.remove_node(switch_ref.id)
+    for port in switch_ref.ports:
+      node = port_node(switch_ref.id, port)
+      self.state.network.remove_node(node)
+
+  def create_probes(self, switch_ref):
+    for port in switch_ref.ports:
+      self.state.probes.add((switch_ref.id, port))
 
   def switch_up(self, switch_id, ports):
     print "switch_up(%s, %s)" % (switch_id, ports)
     self.state.switches[switch_id] = SwitchRef(switch_id, ports)
-    self.state.network.add_node(switch_id)
+    self.add_switch(self.state.switches[switch_id])
+    self.create_probes(self.state.switches[switch_id])
     self.update(self.global_policy())
     
-
   def switch_down(self, switch_id):
     print "switch_down(%s)" % switch_id
+    self.remove_switch(self.state.switches[switch_id])
     del self.state.switches[switch_id]
-    self.state.network.remove_node(switch_id)
     self.update(self.global_policy())
 
+  def handle_probe(self, dst_switch, dst_port, src_switch, src_port):
+    print "Probe received from (%s, %s) to (%s, %s)" % (src_switch, src_port, dst_switch, dst_port)
+    node0 = port_node(dst_switch, dst_port)
+    node1 = port_node(src_switch, src_port)
+    self.state.network.add_edge(node0, node1)
+    self.state.network.add_edge(node1, node0)
+    self.state.probes.discard((dst_switch, dst_port))
+    self.state.probes.discard((src_switch, src_port))
+
   def packet_in(self, switch_id, port_id, payload):
-    print "packet_in(%s,%s,payload)" % (switch_id, port_id)
+    pkt = packet.Packet(array.array('b', payload.data))
+    p = get(pkt, 'ethernet')
+    if (p.ethertype == probocol):
+      data = from_str(p.src)
+      src_switch = data[0]
+      src_port = data[1]
+      self.handle_probe(switch_id, port_id, src_switch, src_port)
 
 
 class State(object):
@@ -81,6 +131,7 @@ class State(object):
   def __init__(self):
     self.network = networkx.Graph()
     self.switches = {}
+    self.probes = set()
 
 def packet_in(self, switch_id, port_id, payload):
   print "Packet in!"

--- a/lang/python/frenetic/examples/discovery/discovery.py
+++ b/lang/python/frenetic/examples/discovery/discovery.py
@@ -1,0 +1,12 @@
+from state import State
+from topology import Topology
+from routing import Routing
+
+def main(version):
+  shared_state = State()
+  topo = Topology(shared_state)
+  app = Routing(shared_state, topo)
+  app.start_event_loop()
+
+if __name__ == '__main__':
+  main(1)

--- a/lang/python/frenetic/examples/discovery/flood_switch.py
+++ b/lang/python/frenetic/examples/discovery/flood_switch.py
@@ -1,0 +1,28 @@
+from frenetic.syntax import *
+
+# Helper class to store switch information
+class SwitchRef(object):
+  def __init__(self, id, ports):
+    self.id = id
+    self.ports = ports
+
+# Create a policy that given a SwitchRef, floods all input to its ports
+def flood_switch_policy(switch):
+  assert isinstance(switch, SwitchRef)
+  pol = False
+  for src in switch.ports:
+    test = Filter(Test(Location(Physical(src))))
+    actions = False
+    for dst in switch.ports:
+      if src == dst:
+        continue
+      action = test >> Mod(Location(Physical(dst)))
+      if not actions:
+        actions = action
+      else:
+        actions = action | actions
+    if not pol:
+      pol = actions
+    else:
+      pol = actions | pol
+  return Filter(Test(Switch(switch.id))) >> pol

--- a/lang/python/frenetic/examples/discovery/routing.py
+++ b/lang/python/frenetic/examples/discovery/routing.py
@@ -1,0 +1,67 @@
+import frenetic, networkx
+from frenetic.syntax import *
+from flood_switch import *
+from state import *
+
+class Routing(frenetic.App):
+
+  client_id = "routing"
+
+  def __init__(self, state, topo):
+    frenetic.App.__init__(self)
+    self.state = state
+    self.state.register(self)
+    self.topo = topo
+
+  def run_update(self):
+    self.update(self.policy() | self.topo.policy())
+
+  def build_path(self, node_list, curr_switch, acc):
+    if not node_list:
+      print "acc len: %s" % len(acc)
+      return Union(acc)
+    next_switch = node_list.pop()
+    out_port = self.state.network[curr_switch][next_switch]['label']
+    pol = Filter(Test(Switch(curr_switch))) >> Mod(Location(Physical(out_port)))
+    print "filter switch = %s; port := %s" % (curr_switch, out_port)
+    acc.append(pol)
+    return self.build_path(node_list, next_switch, acc)
+    
+  def policy(self):
+    hosts = self.state.hosts()
+    paths = []
+ 
+    for src_host in hosts:
+      for dst_host in hosts:
+        if src_host == dst_host:
+          continue
+
+        # Build a copy of the network containing only switches and the relevant hosts
+        network_prime = self.state.network.copy()
+        for host in self.state.hosts():
+          if not (host == src_host or host == dst_host):
+            network_prime.remove_node(host)
+          
+        #If no path exists, skip
+        if(not networkx.has_path(network_prime, src_host, dst_host)):
+          continue
+        # Otherwise, get the path and build that policy
+        node_list = networkx.shortest_path(network_prime, src_host, dst_host)
+        print "Building Path: %s" % node_list
+        node_list.reverse()
+        node_list.pop()
+        test = Filter(Test(EthSrc(src_host)) & Test(EthDst(dst_host)))
+        paths.append(test >> self.build_path(node_list, node_list.pop(), []))
+
+    return (Union(paths) | 
+            Union([flood_switch_policy(switch_ref) for switch_ref in self.state.switches().values()]))
+
+  def packet_in(self, switch_id, port_id, payload):
+    self.topo.packet_in(switch_id, port_id, payload)
+
+  def switch_up(self, switch_id, ports):
+    self.topo.switch_up(switch_id, ports)
+
+  def switch_down(self, switch_id):
+    self.topo.switch_down(switch_id)
+

--- a/lang/python/frenetic/examples/discovery/state.py
+++ b/lang/python/frenetic/examples/discovery/state.py
@@ -1,0 +1,83 @@
+import networkx, struct
+
+class State(object):
+
+  def __init__(self):
+    self.network = networkx.DiGraph()
+    self._switches = {}
+    self.probes = set()
+    self._hosts = set()
+    self._edges = set()
+    self.probes_sent = {}
+    self.tentative_edge = {}
+    self._observers = set()
+    self._clean = True
+
+  def switches(self):
+    return self._switches
+
+  def hosts(self):
+    return self._hosts
+
+  def register(self, observer):
+    self._observers.add(observer)
+
+  def notify(self):
+    if not self._clean:
+      for observer in self._observers:
+        observer.run_update()
+    self._clean = True
+
+  def __cleanup(self, force_notify):
+    self._clean = False
+    if force_notify:
+      self.notify()
+
+  def add_switch(self, switch_ref, force_notify=False):
+    if switch_ref in self._switches:
+      return
+    self._switches[switch_ref.id] = switch_ref
+    self.network.add_node(switch_ref.id)
+    self._clean = False
+    self.__cleanup(force_notify)
+
+  def add_host(self, host, force_notify=False):
+    if host in self._hosts:
+      return
+    self._hosts.add(host)
+    self.network.add_node(host)
+    self._clean = False
+    self.__cleanup(force_notify)
+
+  def add_edge(self, u, v, force_notify=False, **attr):
+    if (u,v) in self._edges:
+      return
+    self._edges.add((u,v))
+    self.network.add_edge(u,v,attr_dict=attr)
+    self._clean = False
+    self.__cleanup(force_notify)
+
+  def remove_switch(self, switch_id, force_notify=False):
+    if switch_id not in self._switches:
+      return
+    del self._switches[switch_id]
+    self.network.remove_node(switch_id)
+    self._clean = False
+    self.__cleanup(force_notify)
+
+  def remove_host(self, host, force_notify=False):
+    if host not in self._hosts:
+      return
+    self._hosts.remove(host)
+    self.network.remove_node(host)
+    self._clean = False
+    self.__cleanup(force_notify)
+
+  def remove_edge(self, u, v, force_notify=False):
+    if (u,v) not in self._edges:
+      return
+    self._edges.remove((u,v))
+    self.network.remove_edge(u, v)
+    self._clean = False
+    self.__cleanup(force_notify)
+    

--- a/lang/python/frenetic/examples/discovery/topology.py
+++ b/lang/python/frenetic/examples/discovery/topology.py
@@ -148,10 +148,6 @@ class Topology(frenetic.App):
     self.state.notify()
       
   def packet_in(self, switch_id, port_id, payload):
-    if(not hasattr(payload, 'data')):
-      # TODO(jcollard): This appears to happen when the payload is Buffered
-      print "Payload didn't have data field."
-      return
     pkt = packet.Packet(array.array('b', payload.data))
     p = get(pkt, 'ethernet')
     if (p.ethertype == ProbeData.PROBOCOL):

--- a/lang/python/frenetic/syntax.py
+++ b/lang/python/frenetic/syntax.py
@@ -168,12 +168,12 @@ class Not(Pred):
           "pred": self.pred.to_json()
         }
 
-class True(Pred):
+class Id(Pred):
 
     def to_json(self):
         return { "type": "true" }
 
-class False(Pred):
+class Drop(Pred):
 
     def to_json(self):
         return { "type": "false" }
@@ -410,7 +410,7 @@ class Seq(Policy):
 
 # Shorthands
 
-true = True()
-false = False()
+true = Id()
+false = Drop()
 id = Filter(true)
 drop = Filter(false)

--- a/lang/python/frenetic/syntax.py
+++ b/lang/python/frenetic/syntax.py
@@ -2,10 +2,10 @@
 import base64
 import collections
 
-class Action:
+class Action(object):
     pass
 
-class Pseudoport:
+class Pseudoport(object):
     pass
 
 class Physical(Pseudoport):
@@ -26,7 +26,7 @@ class Output(Action):
     def to_json(self):
         return { "type": "output", "pseudoport": self.pseudoport.to_json() }
 
-class Payload:
+class Payload(object):
     pass
 
     @staticmethod
@@ -61,7 +61,7 @@ class NotBuffered(Payload):
         return { "type": "notbuffered", "data": base64.b64encode(self.data) }
 
 
-class PacketOut():
+class PacketOut(object):
 
     def __init__(self, switch, payload, actions, in_port = None):
         assert type(switch) == int and switch >= 0
@@ -80,7 +80,7 @@ class PacketOut():
                  "actions": [ action.to_json() for action in self.actions ],
                  "payload": self.payload.to_json() }
 
-class PacketIn():
+class PacketIn(object):
 
     def __init__(self, json):
         assert (json['type'] == 'packet_in')
@@ -136,8 +136,8 @@ class Pred(object):
 class And(Pred):
 
     def __init__(self, children):
-        for a in children:
-          assert isinstance(a,Pred)
+        children = list(children)
+        assert (isinstance(pol,Pred) for pol in children)
         self.children = children
 
     def to_json(self):
@@ -149,8 +149,8 @@ class And(Pred):
 class Or(Pred):
 
     def __init__(self, children):
-        for a in children:
-          assert isinstance(a,Pred)
+        children = list(children)
+        assert (isinstance(pol,Pred) for pol in children)
         self.children = children
 
     def to_json(self):
@@ -389,8 +389,8 @@ class Mod(Policy):
 class Union(Policy):
 
     def __init__(self, children):
-        # TODO: Sequence type?
-        assert isinstance(children,collections.Iterable) and (isinstance(pol,Policy) for pol in children)
+        children = list(children)
+        assert (isinstance(pol,Policy) for pol in children)
         self.children = children
 
     def to_json(self):
@@ -402,7 +402,8 @@ class Union(Policy):
 class Seq(Policy):
 
     def __init__(self, children):
-        assert isinstance(children, collections.Iterable) and (isinstance(pol,Policy) for pol in children)
+        children = list(children)
+        assert (isinstance(pol,Policy) for pol in children)
         self.children = children
 
     def to_json(self):

--- a/lang/python/frenetic/syntax.py
+++ b/lang/python/frenetic/syntax.py
@@ -35,17 +35,20 @@ class Payload:
         if json['id'] == None:
             return NotBuffered(base64.b64decode(json['buffer']))
         else:
-            # TODO(arjun): may have some bytes. do not discard
-            return Buffered(json['id'])
+            return Buffered(json['id'], base64.b64decode(json['buffer']))
 
 
 class Buffered(Payload):
 
-    def __init__(self, buffer_id):
+    def __init__(self, buffer_id, data):
         assert type(buffer_id) == int and buffer_id >= 0
         self.buffer_id = buffer_id
+        self.data = data
 
     def to_json(self):
+        # NOTE(arjun): The data isn't being sent back to OCaml. But, it
+        # doesn't matter, since the buffer ID is all that's needed to process
+        # a buffered packet in a PACKET_OUT message.
         return { "type": "buffered", "bufferid": self.buffer_id }
 
 class NotBuffered(Payload):


### PR DESCRIPTION
*Warning*. In Python, the True and False policies have been renamed to Id and Drop. This is to avoid clashing with Python's builtin True and False. You can always use the constants `true` and `false` (lowercase.)