### PR TITLE
Added Dockerfiles and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,30 @@ To install the Frenetic package, add the following to the end of `/etc/apt/sourc
 
 Then, run `apt-get update && apt-get install frenetic`.
 
+## Using a Docker container
+
+There are two Dockerfiles provided (in the `docker` directory) that will build a
+[Docker image](https://www.docker.com/whatisdocker/) containing Frenetic and its
+dependencies. The `Dockerfile.opam` file creates an image using the current
+stable versions of packages from [OPAM](http://opam.ocamlpro.com/). The
+`Dockerfile.git` creates an image using the most current versions of Frenetic
+and its immediate dependencies from GitHub.
+
+Prebuilt images are available from the
+[Docker Hub](https://hub.docker.com/). You can obtain the
+[stable OPAM version](https://registry.hub.docker.com/u/basus/frenetic/)
+using:
+
+    $ docker pull basus/frenetic
+
+The [Git version](https://registry.hub.docker.com/u/basus/frenetic-git/) can be
+obtained using:
+
+    $ docker pull basus/frenetic-git
+
+Please see the [Docker documentation](http://docs.docker.com/) for more information
+on using Docker.
+
 ## Frenetic HTTP Controller
 
 Instead of using OCaml, you can interact with Frenetic over HTTP.

--- a/docker/Dockerfile.git
+++ b/docker/Dockerfile.git
@@ -1,0 +1,25 @@
+FROM avsm/docker-opam:ubuntu-trusty-4.02.1
+MAINTAINER Shrutarshi Basu <basus@cs.cornell.edu>
+RUN sudo apt-get -y update
+RUN sudo apt-get -y upgrade
+RUN sudo apt-get -y install zlib1g-dev
+RUN cd ~/opam-repository && git pull && opam update -u -y && opam upgrade -y
+RUN opam install core async async_extended fieldslib cmdliner cstruct sexplib \
+                 ulex ipaddr yojson base64 cohttp quickcheck ounit pa_ounit \
+                 tcpip ocamlgraph
+RUN eval `opam config env`
+WORKDIR /home/opam
+RUN git clone https://github.com/frenetic-lang/ocaml-packet.git
+RUN git clone https://github.com/frenetic-lang/ocaml-openflow.git
+RUN git clone https://github.com/frenetic-lang/ocaml-topology.git
+RUN git clone https://github.com/frenetic-lang/frenetic.git
+WORKDIR /home/opam/ocaml-packet
+RUN eval `opam config env` && make && make install
+WORKDIR /home/opam/ocaml-openflow
+RUN eval `opam config env` && make && make install
+WORKDIR /home/opam/ocaml-topology
+RUN eval `opam config env` && make && make install
+WORKDIR /home/opam/frenetic
+RUN eval `opam config env` && make && make install || true
+RUN cp _build/frenetic/frenetic.native $(opam config var bin)/frenetic
+WORKDIR /home/opam/

--- a/docker/Dockerfile.opam
+++ b/docker/Dockerfile.opam
@@ -1,0 +1,7 @@
+FROM avsm/docker-opam:ubuntu-trusty-4.02.1
+MAINTAINER Shrutarshi Basu <basus@cs.cornell.edu>
+RUN sudo apt-get -y update
+RUN sudo apt-get -y install zlib1g-dev
+RUN cd ~/opam-repository && git pull && opam update -u -y
+RUN opam upgrade
+RUN opam install frenetic


### PR DESCRIPTION
Provides two Dockerfiles to build Docker images, either from OPAM packages, or the GitHub Frenetic repos. Also provides basic information in the README to obtain prebuilt images from the Docker Hub.