### PR TITLE
Properly parse 0-n port stats replies

### DIFF
--- a/async/Frenetic_NetKAT_Controller.ml
+++ b/async/Frenetic_NetKAT_Controller.ml
@@ -128,7 +128,7 @@ module type CONTROLLER = sig
   val send_packet_out : switchId -> Frenetic_OpenFlow.pktOut -> unit Deferred.t
   val event : unit -> event Deferred.t
   val query : string -> (Int64.t * Int64.t) Deferred.t
-  val port_stats : switchId -> portId -> OF10.portStats Deferred.t
+  val port_stats : switchId -> portId -> OF10.portStats list Deferred.t
   val is_query : string -> bool
   val start : unit -> unit
   val current_switches : unit -> (switchId * portId list) list
@@ -208,7 +208,7 @@ module Make : CONTROLLER = struct
     let (pkts', bytes') = Hashtbl.Poly.find_exn stats name in
     Deferred.return (Int64.(pkts + pkts', bytes + bytes'))
 
-  let port_stats (sw_id : switchId) (pid : portId) : OF10.portStats Deferred.t =
+  let port_stats (sw_id : switchId) (pid : portId) : OF10.portStats list Deferred.t =
     let pt = Int32.(to_int_exn pid) in 
     let req = OF10.PortRequest (Some (PhysicalPort pt)) in 
     match Controller.send_txn sw_id (OF10.Message.StatsRequestMsg req) with 

--- a/async/Frenetic_NetKAT_Controller.mli
+++ b/async/Frenetic_NetKAT_Controller.mli
@@ -27,7 +27,7 @@ module type CONTROLLER = sig
   val send_packet_out : switchId -> Frenetic_OpenFlow.pktOut -> unit Deferred.t
   val event : unit -> event Deferred.t
   val query : string -> (Int64.t * Int64.t) Deferred.t
-  val port_stats : switchId -> portId -> OF10.portStats Deferred.t
+  val port_stats : switchId -> portId -> OF10.portStats list Deferred.t
   val is_query : string -> bool
   val start : unit -> unit
   val current_switches : unit -> (switchId * portId list) list

--- a/lib/Frenetic_NetKAT_Json.ml
+++ b/lib/Frenetic_NetKAT_Json.ml
@@ -266,21 +266,24 @@ let stats_to_json ((pkts, bytes) : Int64.t * Int64.t) : json =
 let stats_to_json_string (stats : Int64.t * Int64.t) : string =
   Yojson.Basic.to_string ~std:true (stats_to_json stats)
 
-let port_stats_to_json (portStats : Frenetic_OpenFlow0x01.portStats) : json =
-  `Assoc [("port_no", `Int portStats.port_no);
-	  ("rx_packets", `Int (Int64.to_int_exn portStats.rx_packets));
-	  ("tx_packets", `Int (Int64.to_int_exn portStats.tx_packets));
-	  ("rx_bytes", `Int (Int64.to_int_exn portStats.rx_bytes));
-	  ("tx_bytes", `Int (Int64.to_int_exn portStats.tx_bytes));
-	  ("rx_dropped", `Int (Int64.to_int_exn portStats.rx_dropped));
-	  ("tx_dropped", `Int (Int64.to_int_exn portStats.tx_dropped));
-	  ("rx_errors", `Int (Int64.to_int_exn portStats.rx_errors));
-	  ("tx_errors", `Int (Int64.to_int_exn portStats.tx_errors));
-	  ("rx_fram_err", `Int (Int64.to_int_exn portStats.rx_frame_err));
-	  ("rx_over_err", `Int (Int64.to_int_exn portStats.rx_over_err));
-	  ("rx_crc_err", `Int (Int64.to_int_exn portStats.rx_crc_err));
-	  ("collisions", `Int (Int64.to_int_exn portStats.collisions))]
+let port_stat_to_json (portStat: Frenetic_OpenFlow0x01.portStats) : json =
+  `Assoc [("port_no", `Int portStat.port_no);
+    ("rx_packets", `Int (Int64.to_int_exn portStat.rx_packets));
+    ("tx_packets", `Int (Int64.to_int_exn portStat.tx_packets));
+    ("rx_bytes", `Int (Int64.to_int_exn portStat.rx_bytes));
+    ("tx_bytes", `Int (Int64.to_int_exn portStat.tx_bytes));
+    ("rx_dropped", `Int (Int64.to_int_exn portStat.rx_dropped));
+    ("tx_dropped", `Int (Int64.to_int_exn portStat.tx_dropped));
+    ("rx_errors", `Int (Int64.to_int_exn portStat.rx_errors));
+    ("tx_errors", `Int (Int64.to_int_exn portStat.tx_errors));
+    ("rx_fram_err", `Int (Int64.to_int_exn portStat.rx_frame_err));
+    ("rx_over_err", `Int (Int64.to_int_exn portStat.rx_over_err));
+    ("rx_crc_err", `Int (Int64.to_int_exn portStat.rx_crc_err));
+    ("collisions", `Int (Int64.to_int_exn portStat.collisions))]
 
-let port_stats_to_json_string (portStats : Frenetic_OpenFlow0x01.portStats) : string =
+let port_stats_to_json (portStats : Frenetic_OpenFlow0x01.portStats list) : json =
+  `List (List.map portStats ~f:port_stat_to_json)
+
+let port_stats_to_json_string (portStats : Frenetic_OpenFlow0x01.portStats list) : string =
   Yojson.Basic.to_string ~std:true (port_stats_to_json portStats)
 

--- a/lib/Frenetic_NetKAT_Json.mli
+++ b/lib/Frenetic_NetKAT_Json.mli
@@ -14,4 +14,4 @@ val policy_from_json_string : string -> policy
 val event_to_json_string : event -> string
 val policy_to_json_string : policy -> string
 val stats_to_json_string : Int64.t * Int64.t -> string
-val port_stats_to_json_string : Frenetic_OpenFlow0x01.portStats -> string
+val port_stats_to_json_string : Frenetic_OpenFlow0x01.portStats list -> string

--- a/lib/Frenetic_OpenFlow0x01.mli
+++ b/lib/Frenetic_OpenFlow0x01.mli
@@ -197,7 +197,7 @@ type reply =
   | DescriptionRep of descriptionStats
   | IndividualFlowRep of individualStats list
   | AggregateFlowRep of aggregateStats
-  | PortRep of portStats
+  | PortRep of portStats list
 with sexp
 
 type wildcards = 


### PR DESCRIPTION
Returns list of port stats by Json instead of one object.  If port is non-existent or stats are not available, simply sends back [].  

Also handles "get all port stats for each port on a switch" for free if you send port=65535 (as per OpenFlow 1.0 specs).  