### PR TITLE
Don't crash on msgs between Features req and resp

### DIFF
--- a/async/Frenetic_OpenFlow0x01_Controller.ml
+++ b/async/Frenetic_OpenFlow0x01_Controller.ml
@@ -101,8 +101,9 @@ let client_handler (a:Socket.Address.Inet.t) (r:Reader.t) (w:Writer.t) : unit De
       Hashtbl.Poly.add_exn switches ~key:switchId ~data:{ features; send; send_txn };
       Pipe.write_without_pushback events_writer (`Connect (switchId, features));
       loop (Connected threadState)
-    | SentSwitchFeatures, `Ok (hdr,msg) -> 
-      assert false
+    | SentSwitchFeatures, `Ok (hdr,msg) ->
+      (* Ignore messages sent between SwitchFeaturesReq and SwitchFeaturesResp *)
+      loop state
 
     (* Connected *)
     | Connected threadState, `Eof ->


### PR DESCRIPTION
It's legal for switches to send msgs between the features request and response, but our OpenFlow state machine was crashing (assert false). We now just ignore them.

Alternative solution would be to create a queue and save them until the handshake is finished, then deliver them.