### PR TITLE
Swallow writer exceptions instead of printing to log

### DIFF
--- a/async/Frenetic_Http_Controller.ml
+++ b/async/Frenetic_Http_Controller.ml
@@ -58,12 +58,13 @@ let rec propogate_events event =
 (* Gets the client's node in the dataflow graph, or creates it if doesn't exist *)
 let get_client (clientId: string): client =
   Hashtbl.find_or_add clients clientId
-     ~default:(fun () ->
-               printf ~level:`Info "New client %s" clientId;
-               let node = Frenetic_DynGraph.create_source drop in
-               Frenetic_DynGraph.attach node pol;
-	       let (r, w) = Pipe.create () in
-               { policy_node = node; event_reader = r; event_writer =  w })
+    ~default:(fun () ->
+      printf ~level:`Info "New client %s" clientId;
+      let node = Frenetic_DynGraph.create_source drop in
+      Frenetic_DynGraph.attach node pol;
+	    let (r, w) = Pipe.create () in
+      { policy_node = node; event_reader = r; event_writer =  w }
+    )
 
 let handle_request
   (module Controller : Frenetic_NetKAT_Controller.CONTROLLER)
@@ -136,7 +137,11 @@ let handle_request
       Cohttp_async.Server.respond `Not_found
 
 let print_error addr exn =
-  Log.error "%s" (Exn.to_string exn)
+  let monitor_exn = Exn.to_string (Monitor.extract_exn exn) in
+  (* This is really kludgy, but the exception is of unknown type *)
+  match String.substr_index monitor_exn ~pattern:"writer fd unexpectedly closed" with
+  | Some _ ->  Log.info "Ignoring writer exception"
+  | None -> Log.error "%s" monitor_exn
 
 let listen ~http_port ~openflow_port =
   let module Controller = Frenetic_NetKAT_Controller.Make in


### PR DESCRIPTION
As reported in issue #488, certain HTTP problems throw confusing errors into the log.  In particular:

1. App issues GET /client_id/events.  
1.  Frenetic blocks on this request until an event occurs
1.  App dies
1.  Frenetic gets an event of some sort, and tries to return to the HTTP client as a response to the GET.  It throws a "writer fd unexpectedly closed" error to the log (but keeps going).

The fix simply watches for this error and ignores it if it occurs.  Other HTTP errors continue to be logged.