### PR TITLE
Fix Request-Response OpenFlow Transactions

### DIFF
--- a/async/Frenetic_NetKAT_Controller.ml
+++ b/async/Frenetic_NetKAT_Controller.ml
@@ -198,13 +198,13 @@ module Make : CONTROLLER = struct
                 { sr_of_match = pat0x01; sr_table_id = 0xff; sr_out_port = None } in
             Controller.send_txn sw_id (OF10.Message.StatsRequestMsg req) >>= function
               | `Eof -> return (0L,0L)
-              | `Ok l -> begin
-                l >>| function
-                  | [OF10.Message.StatsReplyMsg (IndividualFlowRep stats)] ->
-                    (List.sum (module Int64) stats ~f:(fun stat -> stat.packet_count),
-                     List.sum (module Int64) stats ~f:(fun stat -> stat.byte_count))
-                  | _ -> (0L, 0L)
-              end))
+              | `Ok l -> match l with
+                | [OF10.Message.StatsReplyMsg (IndividualFlowRep stats)] ->
+                  return (List.sum (module Int64) stats ~f:(fun stat -> stat.packet_count),
+                   List.sum (module Int64) stats ~f:(fun stat -> stat.byte_count))
+                | _ -> return (0L, 0L)
+          )
+      )
     >>| fun stats ->
       List.fold (List.concat stats) ~init:(0L, 0L)
         ~f:(fun (pkts, bytes) (pkts', bytes') ->
@@ -221,11 +221,9 @@ module Make : CONTROLLER = struct
     let req = OF10.PortRequest (Some (PhysicalPort pt)) in
     Controller.send_txn sw_id (OF10.Message.StatsRequestMsg req) >>= function
       | `Eof -> assert false
-      | `Ok l -> begin
-        l >>| function
-          | [OF10.Message.StatsReplyMsg (PortRep ps)] -> ps
-          | _ -> assert false
-      end
+      | `Ok l -> match l with
+        | [OF10.Message.StatsReplyMsg (PortRep ps)] -> return ps
+        | _ -> assert false
 
   let is_query (name : string) : bool = Hashtbl.Poly.mem stats name
 

--- a/async/Frenetic_NetKAT_Updates.ml
+++ b/async/Frenetic_NetKAT_Updates.ml
@@ -102,7 +102,7 @@ module PerPacketConsistent (Args : CONSISTENT_UPDATE_ARGS) : UPDATE = struct
 
   let barrier sw =
     Controller.send_txn sw M.BarrierRequest >>= function
-      | `Ok dl -> dl >>= fun _ -> return (Ok ())
+      | `Ok dl -> return (Ok ())
       | `Eof -> return (Error UpdateError)
 
   let install_flows_for sw_id ?old table =

--- a/async/Frenetic_OpenFlow0x01_Controller.ml
+++ b/async/Frenetic_OpenFlow0x01_Controller.ml
@@ -155,18 +155,21 @@ let send_txn swid msg =
   >>= fun sock ->
   let reader = Reader.create (Socket.fd sock) in
   let writer = Writer.create (Socket.fd sock) in
-  Log.debug "send_txn";
   Writer.write_marshal writer ~flags:[] (`Send_txn (swid,msg));
-  Reader.read_marshal reader >>| function
-  | `Eof ->
-    Log.debug "send_txn returned (EOF)";
-    Socket.shutdown sock `Both;
-    `Eof
-  | `Ok (`Send_txn_resp `Eof) ->
-    Log.debug "send_txn returned (EOF)";
-    Socket.shutdown sock `Both;
-    `Eof
-  | `Ok (`Send_txn_resp (`Ok resp)) ->
-    Log.debug "send_txn returned (Ok)";
-    Socket.shutdown sock `Both;
-    resp
+  Reader.read_marshal reader >>| fun resp ->
+    match resp with
+    | `Eof ->
+      Log.debug "send_txn returned (EOF)";
+      Socket.shutdown sock `Both;
+      `Eof
+    | `Ok (`Send_txn_resp `Eof) ->
+      Log.debug "send_txn returned (EOF)";
+      Socket.shutdown sock `Both;
+      `Eof
+    | `Ok (`Send_txn_resp (`Ok resp)) ->
+      Log.debug "send_txn returned (Ok)";
+      Socket.shutdown sock `Both;
+      resp
+    | _ ->
+      Log.debug "send_txn returned something unintelligible";
+      `Eof

--- a/async/Frenetic_OpenFlow0x01_Controller.ml
+++ b/async/Frenetic_OpenFlow0x01_Controller.ml
@@ -159,15 +159,12 @@ let send_txn swid msg =
   Reader.read_marshal reader >>| fun resp ->
     match resp with
     | `Eof ->
-      Log.debug "send_txn returned (EOF)";
       Socket.shutdown sock `Both;
       `Eof
     | `Ok (`Send_txn_resp `Eof) ->
-      Log.debug "send_txn returned (EOF)";
       Socket.shutdown sock `Both;
       `Eof
     | `Ok (`Send_txn_resp (`Ok resp)) ->
-      Log.debug "send_txn returned (Ok)";
       Socket.shutdown sock `Both;
       resp
     | _ ->

--- a/async/Frenetic_OpenFlow0x01_Controller.mli
+++ b/async/Frenetic_OpenFlow0x01_Controller.mli
@@ -19,5 +19,5 @@ val send : switchId -> xid -> Message.t -> [`Ok | `Eof] Deferred.t
 
 val send_batch : switchId -> xid -> Message.t list -> [`Ok | `Eof] Deferred.t
 
-val send_txn : switchId -> Message.t -> [`Ok of (Message.t list) Deferred.t | `Eof] Deferred.t
+val send_txn : switchId -> Message.t -> [`Ok of (Message.t list) | `Eof] Deferred.t
 

--- a/lang/python/frenetic/__init__.py
+++ b/lang/python/frenetic/__init__.py
@@ -86,7 +86,7 @@ class App(object):
       response = ftr.result()
       if(hasattr(response, 'buffer')):
         data = json.loads(response.buffer.getvalue())
-        callback(data[0])
+        callback(data)
 
     @return_future
     def port_stats_helper(self, ftr, callback):

--- a/lang/python/frenetic/__init__.py
+++ b/lang/python/frenetic/__init__.py
@@ -86,10 +86,7 @@ class App(object):
       response = ftr.result()
       if(hasattr(response, 'buffer')):
         data = json.loads(response.buffer.getvalue())
-        dataPrime = {}
-        for key in data:
-          dataPrime[key] = int(data[key])
-        callback(data)
+        callback(data[0])
 
     @return_future
     def port_stats_helper(self, ftr, callback):

--- a/lang/python/frenetic/examples/firewall.py
+++ b/lang/python/frenetic/examples/firewall.py
@@ -208,12 +208,12 @@ class Firewall(frenetic.App):
       tcp = self.packet(payload, "udp")
     else:
       print "Not a TCP or UDP packet. Dropped."
-      self.pkt_out(switch = switch_id, payload = payload, actions = [])
+      self.pkt_out(switch_id = switch_id, payload = payload, actions = [])
       return
 
     if ip == None or tcp == None:
       print "Not TCP/IP packet. Dropped."
-      self.pkt_out(switch = switch_id, payload = payload, actions = [])
+      self.pkt_out(switch_id = switch_id, payload = payload, actions = [])
       return
 
     if self.state.version == 1:

--- a/lang/python/frenetic/examples/port_count.py
+++ b/lang/python/frenetic/examples/port_count.py
@@ -28,7 +28,8 @@ class PortCount(frenetic.App):
 
   def print_count(self, future, switch):
     data = future.result()
-    print "Count %s@%s: {rx_bytes = %s, tx_bytes = %s}" % (switch, data['port_no'], data['rx_bytes'], data['tx_bytes'])
+    for d in data:
+      print "Count %s@%s: {rx_bytes = %s, tx_bytes = %s}" % (switch, d['port_no'], d['rx_bytes'], d['tx_bytes'])
 
   def count_ports(self):
     for switch in self.state.switches:


### PR DESCRIPTION
Frenetic adds a transactional layer for several request-response OpenFlow queries like port_stats.  The layer had a few problems:

- It didn't actually send the request.  It just waited for the response that would never show up.
- It was trying to send Deferreds over a TCP socket from the openflow process to the Frenetic process.   Async would try to deserialize the Deferred message, get really confused, and segfault.  

The fix makes sure all Deferreds are determined before sending the results over the wire.  /port_stats now works.  Need to test other transactional stuff like queries (flow_stats) before merging in.   