### PR TITLE
Added Pipe and Query to Raw NetKAT Syntax

### DIFF
--- a/examples/pipe_and_query.kat
+++ b/examples/pipe_and_query.kat
@@ -1,0 +1,3 @@
+filter port = 1; port := pipe("ctrl") |
+filter port = 2; port := query("qry") |
+filter port = 3; port := 1

--- a/lib/Frenetic_NetKAT_Lexer.mli
+++ b/lib/Frenetic_NetKAT_Lexer.mli
@@ -21,6 +21,7 @@ type token =
   | INT64 of string
   | IP4ADDR of string
   | ANTIQUOT of string
+  | STRING_CONSTANT of string
   | EOI
 
 module Token : sig

--- a/lib/Frenetic_NetKAT_Parser.cppo.ml
+++ b/lib/Frenetic_NetKAT_Parser.cppo.ml
@@ -34,6 +34,8 @@ let nk_int32 = Gram.Entry.mk "nk_int32"
 let nk_int = Gram.Entry.mk "nk_int"
 let nk_ipv4 = Gram.Entry.mk "nk_ipv4"
 let nk_loc = Gram.Entry.mk "nk_loc"
+let nk_string_constant = Gram.Entry.mk "nk_string_constant"
+let nk_pkt_dest = Gram.Entry.mk "nk_pkt_dest"
 
 EXTEND Gram
 
@@ -63,6 +65,10 @@ EXTEND Gram
   nk_loc: [[
       switch = nk_int64; "@"; port = nk_int64 ->
         MK((ID(switch),ID(port)))
+  ]];
+
+  nk_string_constant: [[
+      sc = STRING_CONSTANT -> MK(STR(sc))
   ]];
 
   nk_pred_atom: [[
@@ -130,6 +136,12 @@ EXTEND Gram
       a = nk_pred_or -> a
   ]];
 
+  nk_pkt_dest: [[
+      n = nk_int32 -> MK(Physical n)
+    | "query"; "("; q = nk_string_constant; ")" -> MK(Query q) 
+    | "pipe"; "("; p = nk_string_constant; ")" -> MK(Pipe p) 
+  ]];
+
   nk_pol_atom: [[
       "("; p = nk_pol; ")" -> p
     | "id" ->
@@ -140,8 +152,8 @@ EXTEND Gram
       MK(Filter ID(a))
     | "switch"; ":="; sw = nk_int64 ->
       MK(Mod (Switch ID(sw)))
-    | "port"; ":="; n = nk_int32 ->
-      MK(Mod (Location (Physical ID(n))))
+    | "port"; ":="; l = nk_pkt_dest ->
+      MK(Mod (Location l))
     | "vswitch"; ":="; sw = nk_int64 ->
       MK(Mod (VSwitch ID(sw)))
     | "vport"; ":="; n = nk_int64 ->


### PR DESCRIPTION
NetKAT now supports syntax for pipes and queries:

```
filter port = 1; port := pipe("ctrl") |
filter port = 2; port := query("qry") |
filter port = 3; port := 1
```