### PR TITLE
More Python Extensions

### DIFF
--- a/lang/python/frenetic/__init__.py
+++ b/lang/python/frenetic/__init__.py
@@ -7,7 +7,6 @@ from tornado.ioloop import IOLoop
 from frenetic.syntax import PacketIn, PacketOut
 from tornado.concurrent import return_future
 from tornado import gen
-from ryu.lib.packet import *
 
 AsyncHTTPClient.configure("tornado.curl_httpclient.CurlAsyncHTTPClient")
 
@@ -43,6 +42,7 @@ class App(object):
         print "established connection to Frenetic controller"
 
     def packet(self, payload, protocol):
+        from ryu.lib.packet import packet
         pkt = packet.Packet(array.array('b', payload.data))
         for p in pkt:
             if p.protocol_name == protocol:
@@ -50,10 +50,7 @@ class App(object):
         return None
 
     def pkt_out(self, switch_id, payload, actions, in_port=None):
-        msg = PacketOut(switch=switch_id,
-                        payload=payload,
-                        actions=actions,
-                        in_port=in_port)
+        msg = PacketOut(switch=switch_id, payload=payload, actions=actions, in_port=in_port)
         pkt_out_url = "http://%s:%s/pkt_out" % (self.frenetic_http_host, self.frenetic_http_port)
         request = HTTPRequest(pkt_out_url, method='POST', body=json.dumps(msg.to_json()))
         return self.__http_client.fetch(request)

--- a/lang/python/frenetic/examples/discovery/flood_switch.py
+++ b/lang/python/frenetic/examples/discovery/flood_switch.py
@@ -19,22 +19,11 @@ class SwitchRef(object):
 # Create a policy that given a SwitchRef, floods all input to its ports
 def flood_switch_policy(switch):
   assert isinstance(switch, SwitchRef)
-  pol = False
+  all_policies = []
   for src in switch.ports:
-    test = Filter(PortEq(src))
-    actions = False
-    for dst in switch.ports:
-      if src == dst:
-        continue
-      action = test >> SetPort(dst)
-      if not actions:
-        actions = action
-      else:
-        actions = action | actions
-    if not pol:
-      pol = actions
-    else:
-      pol = actions | pol
-  if not pol:
+    action = Filter(PortEq(src)) >> SetPort([dst for dst in switch.ports if src != dst])
+    all_policies.append(action)
+
+  if not all_policies:
     return Filter(SwitchEq(switch.id)) >> drop
-  return Filter(SwitchEq(switch.id)) >> pol
+  return Filter(SwitchEq(switch.id)) >> Union(all_policies)

--- a/lang/python/frenetic/examples/discovery/topology.py
+++ b/lang/python/frenetic/examples/discovery/topology.py
@@ -40,7 +40,6 @@ class Count(object):
 class Topology(frenetic.App):
 
   client_id = "topology"
-  # TODO: Make these settable at command line.  Below are defaults.
   frenetic_http_host = "localhost"
   frenetic_http_port = "9000"
 
@@ -55,8 +54,7 @@ class Topology(frenetic.App):
     self.update(self.policy())
 
     IOLoop.instance().add_timeout(datetime.timedelta(seconds=2), self.run_probe)
-    # TODO: Set back to 30
-    IOLoop.instance().add_timeout(datetime.timedelta(seconds=10), self.host_discovery)
+    IOLoop.instance().add_timeout(datetime.timedelta(seconds=30), self.host_discovery)
 
     # The controller may already be connected to several switches on startup.
     # This ensures that we probe them too.
@@ -157,8 +155,7 @@ class Topology(frenetic.App):
       sniff = Filter(EthTypeEq(0x806)) >> SendToController("http")
       return probe_traffic | sniff
     elif self.state.mode == "host_discovery":
-      #TODO: Remove 0x800
-      sniff = Filter(EthTypeEq(0x806,0x800)) >> SendToController("http")
+      sniff = Filter(EthTypeEq(0x806)) >> SendToController("http")
       return sniff
     else:
       assert False

--- a/lang/python/frenetic/examples/firewall.py
+++ b/lang/python/frenetic/examples/firewall.py
@@ -1,6 +1,7 @@
 import frenetic, sys, json, time
 from functools import partial
 from frenetic.syntax import *
+from frenetic.packet import *
 import single_switch_forwarding
 import array
 from ryu.lib.packet import packet

--- a/lang/python/frenetic/examples/flood_switch.py
+++ b/lang/python/frenetic/examples/flood_switch.py
@@ -9,22 +9,11 @@ class SwitchRef(object):
 # Create a policy that given a SwitchRef, floods all input to its ports
 def flood_switch_policy(switch):
   assert isinstance(switch, SwitchRef)
-  pol = False
+  all_policies = []
   for src in switch.ports:
-    test = Filter(PortEq(src))
-    actions = False
-    for dst in switch.ports:
-      if src == dst:
-        continue
-      action = test >> SetPort(dst)
-      if not actions:
-        actions = action
-      else:
-        actions = action | actions
-    if not pol:
-      pol = actions
-    else:
-      pol = actions | pol
-  if not pol:
+    action = Filter(PortEq(src)) >> SetPort([for dst in switch.ports if src != dst])
+    all_policies.append(action)
+
+  if not all_policies:
     return Filter(SwitchEq(switch.id)) >> drop
-  return Filter(SwitchEq(switch.id)) >> pol
+  return Filter(SwitchEq(switch.id)) >> Union(all_policies)

--- a/lang/python/frenetic/examples/flood_switch.py
+++ b/lang/python/frenetic/examples/flood_switch.py
@@ -11,7 +11,7 @@ def flood_switch_policy(switch):
   assert isinstance(switch, SwitchRef)
   all_policies = []
   for src in switch.ports:
-    action = Filter(PortEq(src)) >> SetPort([for dst in switch.ports if src != dst])
+    action = Filter(PortEq(src)) >> SetPort([dst for dst in switch.ports if src != dst])
     all_policies.append(action)
 
   if not all_policies:

--- a/lang/python/frenetic/examples/packet_in_out.py
+++ b/lang/python/frenetic/examples/packet_in_out.py
@@ -15,7 +15,7 @@ class MyApp(frenetic.App):
   def packet_in(self, sw, pt, payload):
     self.pkt_out(switch_id = sw,
                  payload = payload,
-                 actions = [Output(Physical(other_port(pt)))])
+                 actions = [SetPort(other_port(pt))])
 
 
 print "Run mn --controller=remote --topo=single,2"

--- a/lang/python/frenetic/examples/packet_in_out.py
+++ b/lang/python/frenetic/examples/packet_in_out.py
@@ -5,10 +5,7 @@ from frenetic.syntax import *
 
 def other_port(pt):
   assert (pt == 1 or pt == 2)
-  if pt == 1:
-    return 2
-  else:
-    return 1
+  return 2 if pt == 1 else 1
 
 class MyApp(frenetic.App):
 

--- a/lang/python/frenetic/examples/repeater.py
+++ b/lang/python/frenetic/examples/repeater.py
@@ -26,8 +26,7 @@ class MyApp(frenetic.App):
         return Filter( SwitchEq(sw) ) >> p
 
     def port_policy(self, in_port, ports):
-        out_ports = [port for port in ports if port != in_port]
-        p = Union(SetPort(p) for p in out_ports)
+        p = SetPort([port for port in ports if port != in_port])
         return Filter( PortEq(in_port) ) >> p
 
     def switch_up(self,switch_id,ports):

--- a/lang/python/frenetic/examples/silly.py
+++ b/lang/python/frenetic/examples/silly.py
@@ -18,7 +18,7 @@ class SillyRepeaterApp(frenetic.App):
         self.current_switches(callback=handle_current_switches)        
 
     def packet_in(self, switch_id, port_id, payload):
-        self.pkt_out(switch_id = switch_id, payload = payload, actions = [Output(Physical(port_id))])
+        self.pkt_out(switch_id = switch_id, payload = payload, actions = [SetPort(port_id)])
 
 if __name__ == '__main__':
     app = SillyRepeaterApp()

--- a/lang/python/frenetic/net_utils.py
+++ b/lang/python/frenetic/net_utils.py
@@ -1,0 +1,65 @@
+# net_utils
+# static utliity functions for network-y calculations like subnet masking.
+
+import array
+from ryu.lib.packet import packet
+
+class NetUtils():
+
+  @staticmethod
+  # Stolen from RYU.  This is part of the RyuApp class, so we can't use it directly.
+  def ipv4_to_str(integre):
+    ip_list = [str((integre >> (24 - (n * 8)) & 255)) for n in range(4)]
+    return '.'.join(ip_list)
+
+  @staticmethod
+  def ipv4_to_int(string):
+    ip = string.split('.')
+    assert len(ip) == 4
+    i = 0
+    for b in ip:
+      b = int(b)
+      i = (i << 8) | b
+    return i
+
+  @staticmethod
+  def net_mask(net_mask_combo):
+    # The net is assumed of the form xx.xx.xx.xx/mask using the CIDR notation, as per IP custom
+    (net, mask) = net_mask_combo.split("/")
+    return (net, int(mask))
+
+  # Given a network and a host, construct an IP.  A lot of the path mapping
+  # is done this way, so host x.100 on the real network gets mapped to the bogus addresses 
+  # x1.100, x2.100 and x3.100 for each of the paths
+  @staticmethod
+  def ip_for_network(net, host):
+    (net, mask) = NetUtils.net_mask(net)
+    # Most of the time, the net is in the proper form with zeroes in the right places, but we 
+    # run it through a subnet filter just in case it isn't.
+    net_int = NetUtils.ipv4_to_int(net)
+    # A mask of all ones is just 2^(n+1) -1
+    all_ones = pow(2, mask+1) -1  
+    net_int = net_int & (all_ones << (32-mask))
+    ip_int = net_int | int(host)
+    return NetUtils.ipv4_to_str(ip_int)
+
+  # Given a network and an IP, extract just the host number.
+  @staticmethod
+  def host_of_ip(src_ip, net):
+    (net, mask) = NetUtils.net_mask(net)
+    src_ip_int = NetUtils.ipv4_to_int(src_ip)
+    net_int = NetUtils.ipv4_to_int(net)
+    # A mask of all ones is just 2^(n+1) -1.  The host mask is just the inverse of the net mask
+    all_ones = pow(2, mask+1) -1
+    host_int = ~ (all_ones << (32-mask))
+    return host_int & int(src_ip_int)
+
+  # Given a network and an IP, is the IP in the network?
+  @staticmethod
+  def ip_in_network(src_ip, net):
+    (net, mask) = NetUtils.net_mask(net)
+    net_int = NetUtils.ipv4_to_int(net)
+    net_mask = (pow(2, mask+1) -1) << (32-mask)
+    net_int = net_int & net_mask   # Most likely, there is no change here
+    src_net_int = NetUtils.ipv4_to_int(src_ip) & net_mask
+    return net_int == src_net_int

--- a/lang/python/frenetic/packet.py
+++ b/lang/python/frenetic/packet.py
@@ -197,5 +197,11 @@ class Packet(object):
     return NotBuffered(binascii.a2b_base64(binascii.b2a_base64(p.data)))
 
   def __str__(self):
-    # TODO: Finish this.
-    return "Hi mom!"
+    retval = "{ethSrc: "+self.ethSrc+", ethDst: "+self.ethDst+", ethType: "+str(self.ethType)
+    if (self.vlan != None):
+      retval += ", vlan: "+str(self.vlan)+", vlan: "+str(self.vlanPcp)
+    if (self.ip4Src != None):
+      retval += ", ip4Src: "+self.ip4Src+", ip4Dst: "+self.ip4Dst+", ipProto: "+str(self.ipProto)
+    if (self.tcpSrcPort != None):
+      retval += ", tcpSrcPort: "+str(self.tcpSrcPort)+", tcpDstPort: "+str(self.tcpDstPort)
+    return retval + "}"

--- a/lang/python/frenetic/packet.py
+++ b/lang/python/frenetic/packet.py
@@ -1,0 +1,117 @@
+# Abstract representation of a packet for use in PacketIn and PacketOut
+import array
+from frenetic.syntax import *
+from ryu.lib.packet import packet, ethernet, arp
+
+class Packet(object):
+
+  def __init__(self, dpid, port_id, payload):
+    if isinstance(payload, Payload):
+      raw_data = payload.data
+
+      # Parse the stuff out from any protocol
+      pkt = packet.Packet(array.array('b', raw_data))
+
+      # We start with a clean slate to accomodate all different packet types
+      self.switch = dpid
+      self.port = port_id
+      self.ethSrc = None
+      self.ethDst = None
+      self.ethType = None
+      self.vlan = None
+      self.vlanPcp = None
+      self.ip4Src = None
+      self.ip4Dst = None
+      self.ipProto = None
+      self.tcpSrcPort = None
+      self.tcpDstPort = None
+      self.arpOpcode = None
+      self.arpSrcMac = None
+      self.arpSrcIp = None
+      self.arpDstMac = None
+      self.arpDstIp = None
+
+      for p in pkt:
+        if p.protocol_name == 'ethernet':
+          self.ethSrc = p.src
+          self.ethDst = p.dst
+          if p.ethertype != 0x8100:
+            self.ethType = p.ethertype
+        elif p.protocol_name == 'vlan':
+          self.vlan = p.vid
+          self.vlanPcp = p.pcp
+          # When this is a Vlan packet, ethernet type comes
+          # from the Inner packet, not the Vlan envelope
+          self.ethType = p.ethertype
+        elif p.protocol_name == 'ipv4':
+          self.ip4Src = p.src
+          self.ip4Dst = p.dst
+          self.ipProto = p.proto
+        elif p.protocol_name == 'tcp' or p.protocol_name == 'udp':
+          self.tcpSrcPort = p.src_port
+          self.tcpDstPort = p.dst_port
+        elif p.protocol_name == 'arp':
+          # These are not part of the OpenFlow match protocol, but
+          # they're used so often, we include them
+          self.arpOpcode = p.opcode
+          self.arpSrcMac = p.src_mac
+          self.arpSrcIp = p.src_ip
+          self.arpDstMac = p.dst_mac
+          self.arpDstIp = p.dst_ip
+
+  # Translates JSON attribute names to NetKAT-compatible ones
+  TRANSLATE_JSON_ATTRIBUTE_NAMES = {
+    "switch": "switch",
+    "location": "port",
+    "ethsrc": "ethSrc",
+    "ethdst": "ethDst",
+    "ethtype": "ethType",
+    "vlan": "vlan",
+    "vlanpcp": "vlanPcp",
+    "ip4src": "ip4Src",
+    "ip4dst": "ip4Dst",
+    "ipproto": "ipProto",
+    "tcpsrcport": "tcpSrcPort",
+    "tcpdstport": "tcpDstPort",
+  }
+
+  def get_header_value(self, header_name):
+    return getattr(self, self.TRANSLATE_JSON_ATTRIBUTE_NAMES[header_name])
+
+  def matches(self, pred):
+    # Easy cases
+    if isinstance(pred, Id):
+      return True
+    elif isinstance(pred, Drop):
+      return False
+
+    # Boolean operators
+    elif isinstance(pred, And):
+      # Use short-circuit evaluation
+      for p in pred.children:
+        if not self.matches(p):
+          return False
+      return True
+    elif isinstance(pred, Or):
+      # Use short-circuit evaluation
+      for p in pred.children:
+        if self.matches(p):
+          return True
+      return False
+    elif isinstance(pred, Not):
+      return not self.matches(pred.pred)
+
+    # Base cases
+    elif isinstance(pred, MultiPred):
+      return self.matches(pred.hv)
+    elif isinstance(pred, Test):
+      header_value = pred.hv
+      header = header_value.header
+      value = header_value.value
+      # Location is a special case.  An incoming packet will only match a physical port
+      if header == "location":
+        value = value.port
+      return self.get_header_value(header) == value
+
+    else:
+      raise "unrecognized predicate: "+str(pred)

--- a/lang/python/frenetic/syntax.py
+++ b/lang/python/frenetic/syntax.py
@@ -68,13 +68,16 @@ class PacketOut(object):
         self.switch = switch
         assert isinstance(payload,Buffered) or isinstance(payload,NotBuffered)
         self.payload = payload
-        assert isinstance(actions,list) or isinstance(actions, Seq)
+        assert isinstance(actions,list) or isinstance(actions, Seq) or \
+            isinstance(actions,SinglePolicy) or isinstance(actions,SetPort)
 
         # We flatten all Sequences into lists of actions.  (We don't do this for 
         # Unions because packet outs can't send out parallel packets except for 
         # multiple ports, which we deal with separately.)
         if isinstance(actions, Seq):
             actions = actions.children
+        elif isinstance(actions,SinglePolicy) or isinstance(actions,SetPort):
+            actions = [actions]
 
         scrubbed_actions = []
         for action in actions:
@@ -739,6 +742,11 @@ class SendToController(SinglePolicy):
     def __init__(self, value):
         assert(type(value) == str or type(value == unicode))
         self.hv = Mod(Location(Pipe(value)))
+
+class SendToQuery(SinglePolicy):
+    def __init__(self, value):
+        assert(type(value) == str or type(value == unicode))
+        self.hv = Mod(Location(Query(value)))
 
 class CompilerOptions:
 

--- a/lang/python/frenetic/syntax.py
+++ b/lang/python/frenetic/syntax.py
@@ -68,9 +68,37 @@ class PacketOut(object):
         self.switch = switch
         assert isinstance(payload,Buffered) or isinstance(payload,NotBuffered)
         self.payload = payload
-        #TODO: Can this be refined? Currently list<'instance'>
-        assert isinstance(actions,list)
-        self.actions = actions
+        assert isinstance(actions,list) or isinstance(actions, Seq)
+
+        # We flatten all Sequences into lists of actions.  (We don't do this for 
+        # Unions because packet outs can't send out parallel packets except for 
+        # multiple ports, which we deal with separately.)
+        if isinstance(actions, Seq):
+            actions = actions.children
+
+        scrubbed_actions = []
+        for action in actions:
+            assert isinstance(action, Mod) or isinstance(action, Output) or \
+                isinstance(action,SinglePolicy) or isinstance(action,SetPort) 
+            # In Frenetic 4.0, Mod(Location()) is not accepted.  When the plugin architecture
+            # of 4.1 is instated, this will change, but for the time being, convert a Mod(Location()) 
+            # to an Output for convenience
+            if isinstance(action, Mod): 
+                if action.hv.header == "location":
+                    assert isinstance(action.hv.value, Physical), "Only port outputs are allowed in pkt_out" 
+                    scrubbed_actions.append(Output(Physical(action.hv.value.port)))
+                else:
+                    scrubbed_actions.append(action)
+            # A SetPort might have many destinations, so we convert them here.
+            elif isinstance(action, SetPort):
+                for p in action.port_list:
+                    scrubbed_actions.append(Output(Physical(p)))
+
+            # All others have no scrubbing involved
+            else:
+                scrubbed_actions.append(action)
+
+        self.actions = scrubbed_actions
         assert in_port == None or (type(in_port) == int and in_port >= 0)
         self.in_port = in_port
 
@@ -86,11 +114,9 @@ class PacketIn(object):
         assert (json['type'] == 'packet_in')
         assert type(json['switch_id']) == int and json['switch_id'] >= 0
         self.switch_id = json['switch_id']
-        assert type(json['port_id']) == int and json['switch_id'] >= 0
+        assert type(json['port_id']) == int and json['port_id'] >= 0
         self.port_id = json['port_id']
-        # TODO: assert isinstance(payload,Buffered) or isinstance(payload,NotBuffered)
         self.payload = Payload.from_json(json['payload'])
-
 
 class Stats(object):
 
@@ -616,17 +642,53 @@ def str_policy(klazz, value):
     assert(type(value) == str or type(value == unicode))
     return Mod(klazz(value))
 
+def int_list_policy(klazz, *values):
+    if type(values[0]) == list:
+        values = values[0]
+    vs = []
+    for v in values:
+        if type(v) == str:
+            v = int(v)
+        assert(type(v) == int and v >= 0)
+        vs.append(v)
+    expanded_preds = [ Test(klass(v)) for v in vs ]
+    if len(expanded_preds) > 1:
+        return Or(expanded_preds)
+    elif len(expanded_preds) == 0:
+        return false
+    else:
+        return expanded_preds[0]
+
+# SetPort is a unique case in modifications.  It can take more than one
+# output port, similar to a MultiPred.  
+class SetPort(Policy):
+    def __init__(self, *values):
+        if type(values[0]) == list:
+            values = values[0]
+        vs = []
+        for v in values:
+            if type(v) == str:
+                v = int(v)
+            assert(type(v) == int and v >= 1 and v <= 65535)
+            vs.append(v)
+
+        # Also unlike other Mods, we simply leave the port list alone
+        # instead of immediately turning into a HeaderValue.  That's because
+        # we might use this in a rule or a Packet Out action
+        self.port_list = vs
+
+    def to_json(self):
+        actions = [Mod(Location(Physical(p))) for p in self.port_list]
+        # If there's more than one, Union them together so packet is copied
+        if len(actions) > 1:
+            full_policy = Union(actions)
+            return full_policy.to_json()
+        else:
+            return actions[0].to_json()
+
 class SinglePolicy(Policy):
     def to_json(self):
         return self.hv.to_json()
-
-# With SetPort we do extra checking to make sure the port id is legal OpenFlow
-class SetPort(SinglePolicy):
-    def __init__(self, value):
-        if (type(value)) == str:
-            value = int(value)
-        assert(type(value) == int and value >= 1 and value <= 65535)
-        self.hv = Mod(Location(Physical(value)))
 
 class SetEthSrc(SinglePolicy):
     def __init__(self, value):
@@ -662,18 +724,14 @@ class SetTCPDstPort(SinglePolicy):
 
 # IP4Src and Ip4Dst are weird because they may contain a mask
 class SetIP4Src(SinglePolicy):
-    def __init__(self, value, mask = None):
+    def __init__(self, value):
         assert(type(value) == str or type(value == unicode))
-        if mask != None:
-            assert type(mask) == int
-        self.hv = Mod(IP4Src(value, mask))
+        self.hv = Mod(IP4Src(value, None))
 
 class SetIP4Dst(SinglePolicy):
-    def __init__(self, value, mask = None):
+    def __init__(self, value):
         assert(type(value) == str or type(value == unicode))
-        if mask != None:
-            assert type(mask) == int
-        self.hv = Mod(IP4Dst(value, mask))
+        self.hv = Mod(IP4Dst(value, None))
 
 ############### Misc.
 

--- a/lang/python/frenetic/tests/test_packet.py
+++ b/lang/python/frenetic/tests/test_packet.py
@@ -1,0 +1,87 @@
+# This makes sure we grab Frenetic from sandbox, rather than dsitribution
+import sys, binascii
+sys.path.append('../..')
+import unittest
+from frenetic.syntax import *
+from frenetic.packet import Packet
+from ryu.lib.packet import packet, ethernet, arp, ipv4, tcp
+from ryu.ofproto import ether
+
+class SimpleTestCase(unittest.TestCase):
+  def setUp(self):
+    pass
+
+ETHERNET_DATA = {
+  "dst_mac": "00:01:02:03:04:05",
+  "src_mac": "05:04:03:02:01:00",
+  "ethertype": 0x8888
+}
+
+def sampleEthernetPayload():
+  e = ethernet.ethernet(
+    dst=ETHERNET_DATA["dst_mac"], src=ETHERNET_DATA["src_mac"], ethertype=ETHERNET_DATA["ethertype"]
+  )
+  p = packet.Packet()
+  p.add_protocol(e)
+  p.serialize()
+  return NotBuffered(binascii.a2b_base64(binascii.b2a_base64(p.data)))
+
+TCP_DATA = {
+  "ethertype": 0x0800,
+  "src_ip": "192.168.0.100",
+  "dst_ip": "192.168.0.101",
+  "src_port": 16789,
+  "dst_port": 80,
+  "proto": 6
+}
+
+def sampleTcpPayload():
+  e = ethernet.ethernet(
+    dst=ETHERNET_DATA["dst_mac"], src=ETHERNET_DATA["src_mac"], ethertype=TCP_DATA["ethertype"]
+  )
+  pip = ipv4.ipv4(src=TCP_DATA["src_ip"], dst=TCP_DATA["dst_ip"], proto=TCP_DATA["proto"])
+  ptcp = tcp.tcp(src_port=TCP_DATA["src_port"], dst_port=TCP_DATA["dst_port"])
+  p = packet.Packet()
+  p.add_protocol(e)
+  p.add_protocol(pip)
+  p.add_protocol(ptcp)
+  p.serialize()
+  return NotBuffered(binascii.a2b_base64(binascii.b2a_base64(p.data)))
+
+class ParseEthernetPacket(SimpleTestCase):
+  def runTest(self):
+    payload = sampleEthernetPayload()
+    pkt = Packet(1,2,payload)
+    self.assertEquals(pkt.switch, 1)
+    self.assertEquals(pkt.port, 2)
+    self.assertEquals(pkt.ethDst, ETHERNET_DATA["dst_mac"])
+    self.assertEquals(pkt.ethSrc, ETHERNET_DATA["src_mac"])
+    self.assertEquals(pkt.ethType, ETHERNET_DATA["ethertype"])
+    self.assertEquals(pkt.ip4Src, None)
+
+class ParseTcpPacket(SimpleTestCase):
+  def runTest(self):
+    payload = sampleTcpPayload()
+    pkt = Packet(1,2,payload)
+    self.assertEquals(pkt.switch, 1)
+    self.assertEquals(pkt.port, 2)
+    self.assertEquals(pkt.ethDst, ETHERNET_DATA["dst_mac"])
+    self.assertEquals(pkt.ethSrc, ETHERNET_DATA["src_mac"])
+    self.assertEquals(pkt.ethType, TCP_DATA["ethertype"])
+    self.assertEquals(pkt.ip4Src, TCP_DATA["src_ip"])
+    self.assertEquals(pkt.ip4Dst, TCP_DATA["dst_ip"])
+    self.assertEquals(pkt.ipProto, TCP_DATA["proto"])
+    self.assertEquals(pkt.tcpSrcPort, TCP_DATA["src_port"])
+    self.assertEquals(pkt.tcpDstPort, TCP_DATA["dst_port"])
+
+class MatchesEthernetPacket(SimpleTestCase):
+  def runTest(self):
+    payload = sampleEthernetPayload()
+    pkt = Packet(1,2,payload)
+    self.assertTrue(pkt.matches(SwitchEq(1)))
+    self.assertFalse(pkt.matches(SwitchEq(2))) 
+    self.assertTrue(pkt.matches(EthSrcEq( ETHERNET_DATA["src_mac"] )))
+    self.assertTrue(pkt.matches(PortEq(2)))
+    self.assertTrue(pkt.matches(SwitchEq(1) & PortEq(2)))
+    self.assertTrue(pkt.matches(SwitchEq(23452345) | PortEq(2)))
+    self.assertTrue(pkt.matches(~ SwitchEq(23452345)))

--- a/lang/python/frenetic/tests/test_packet.py
+++ b/lang/python/frenetic/tests/test_packet.py
@@ -51,7 +51,7 @@ def sampleTcpPayload():
 class ParseEthernetPacket(SimpleTestCase):
   def runTest(self):
     payload = sampleEthernetPayload()
-    pkt = Packet(1,2,payload)
+    pkt = Packet.from_payload(1,2,payload)
     self.assertEquals(pkt.switch, 1)
     self.assertEquals(pkt.port, 2)
     self.assertEquals(pkt.ethDst, ETHERNET_DATA["dst_mac"])
@@ -62,7 +62,7 @@ class ParseEthernetPacket(SimpleTestCase):
 class ParseTcpPacket(SimpleTestCase):
   def runTest(self):
     payload = sampleTcpPayload()
-    pkt = Packet(1,2,payload)
+    pkt = Packet.from_payload(1,2,payload)
     self.assertEquals(pkt.switch, 1)
     self.assertEquals(pkt.port, 2)
     self.assertEquals(pkt.ethDst, ETHERNET_DATA["dst_mac"])
@@ -77,7 +77,7 @@ class ParseTcpPacket(SimpleTestCase):
 class MatchesEthernetPacket(SimpleTestCase):
   def runTest(self):
     payload = sampleEthernetPayload()
-    pkt = Packet(1,2,payload)
+    pkt = Packet.from_payload(1,2,payload)
     self.assertTrue(pkt.matches(SwitchEq(1)))
     self.assertFalse(pkt.matches(SwitchEq(2))) 
     self.assertTrue(pkt.matches(EthSrcEq( ETHERNET_DATA["src_mac"] )))
@@ -85,3 +85,14 @@ class MatchesEthernetPacket(SimpleTestCase):
     self.assertTrue(pkt.matches(SwitchEq(1) & PortEq(2)))
     self.assertTrue(pkt.matches(SwitchEq(23452345) | PortEq(2)))
     self.assertTrue(pkt.matches(~ SwitchEq(23452345)))
+
+class MatchesTcpPacket(SimpleTestCase):
+  def runTest(self):
+    payload = sampleTcpPayload()
+    pkt = Packet.from_payload(1,2,payload)
+    self.assertTrue(pkt.matches(TCPSrcPortEq(TCP_DATA["src_port"]) & TCPDstPortEq(TCP_DATA["dst_port"])))
+    self.assertTrue(pkt.matches(IP4SrcEq(TCP_DATA["src_ip"])))
+    # Network matches
+    self.assertTrue(pkt.matches(IP4SrcEq("192.168.0.0",24)))
+    self.assertTrue(pkt.matches(IP4DstEq("192.168.0.101",32)))
+    self.assertTrue(pkt.matches(IP4DstEq("192.168.0.0",16)))


### PR DESCRIPTION
Added the following syntactic sugar to Python bindings.  All are backwards compatible.  

* `SetPort(n)` should be usable in a Packet Out as a synonym for `Output(Physical(n))`.  Other Set's (synonyms for Mod(Field())) can be used in either a Packet Out action list or a NetKAT policy.
* A `Seq` of policies should be able to used in a Packet Out command as a synonym for a list of policies.  
* `SetPort(p1, p2, ... pn)` should be a synonym for `SetPort(p1) | SetPort(p2) | ... | SetPort(pn)`.  
* Parsing a packet and testing header values using RYU Packet Library treads the same ground as a NetKAT predicate.  You should be able to use NetKAT predicates directly in the controller's Packet In handler - e.g. `self.matches(payload, PortEq(23) & EthTypeEq(0x800))`.  That way you have to only learn one predicate language: NetKAT.  Python then pretty much emulates the OpenFlow matcher.  
* Similarly, you should be able to extract values from a payload without touching RYU Packet library at all.  A simple `packet = Packet.from_payload(switch, port, payload)` should return a packet with all the OpenFlow fields in a dict, so that `packet.ethType` is 0x800.  Though this doesn't cover cases where the fields you want are not exposed by OpenFlow (e.g. ARP opcodes or custom probe packet information), it makes the majority of cases MUCH easier.  
* `SendToQuery("tag")` is now a synonym for `Mod(Output(Query("tag")))`

Changed all examples to use these newer constructs.  