### PR TITLE
Attempt Simple Fix for Travis Doc Gen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
   - bash -ex .travis-docgen.sh
 env:
   matrix:
-  - OCAML_VERSION=latest PACKAGE=frenetic TESTS=true BASE_REMOTE=https://opam.ocaml.org
+  - OCAML_VERSION=latest PACKAGE=frenetic TESTS=true BASE_REMOTE=https://opam.ocaml.org KEEP=1
   global:
     secure: Knubza2foy3fm4iKfXTE+DBxQE0XjeT8PN4O1aXZpLqZAGuCt3UU1gOs03lUzbqjU6IOzV8H2y4ctQ7eHiTK9G/kQawSZZtOb15oDOGa8zBM/1tA06GjrBIJhqOk3R6ro0V8eU3W3BqqrbR0cZhGaASFJ2tTDiX53G9dEFJWqho=
 notifications:
@@ -23,4 +23,3 @@ notifications:
 branches:
   only:
     - master
-    - issue_233_docs


### PR DESCRIPTION
To be honest, automatic doc gen by Travis has worked exactly once since it was installed on March 10.  Though the API docs were not installed, they didn't cause a build failure ... unitl June 15 when the authors of travis-docgen.sh attempted a fix which may hva fixed other problems but broke our build.  

This is an attempt to skirt around the Unbound Variable error mentioned in #516.  If it doesn't work, I'll just pull API doc gen out until they can get it fixed correctly.  