### PR TITLE
Set OFPVID_PRESENT bits in marshaling of OxmVlanVId fields in OF1.3

### DIFF
--- a/lib/Frenetic_OpenFlow0x04.ml
+++ b/lib/Frenetic_OpenFlow0x04.ml
@@ -2001,7 +2001,12 @@ module Oxm = struct
       end
     | OxmVlanVId vid ->
       set_ofp_oxm buf ofc OFPXMT_OFB_VLAN_VID (match vid.m_mask with None -> 0 | _ -> 1) l;
-      set_ofp_uint16_value buf2 vid.m_value;
+      (* Set OFPVID_PRESENT bits of ofp_vlan_id field.
+       * Without this flag set, openflow ignores the vid being matched against or set.
+       *
+       * NOTE: Are there cases where we would explicitly match against or set the vlan_id
+       * field for which these bits should be set to OFPVID_NONE? *)
+      set_ofp_uint16_value buf2 (vid.m_value lor 0x1000);
       begin match vid.m_mask with
         | None ->
           sizeof_ofp_oxm + l


### PR DESCRIPTION
Without setting these bits, matches against and writes to a packet's vlan id are ignored. 