### PR TITLE
Fix bug with `Frenetic_Ox.switch_disconnected` handler.

### DIFF
--- a/async/Frenetic_Ox.ml
+++ b/async/Frenetic_Ox.ml
@@ -105,6 +105,7 @@ module Make (Handlers:OXMODULE) = struct
           | _ -> ())
     | SwitchDown sw -> 
       Log.info "switch %Ld disconnected\n%!" sw;
+      Handlers.switch_disconnected sw;
       return ()
     | PortUp (sw,port) -> 
       Log.info "Port %ld on Switch %Ld connected\n%!" port sw;


### PR DESCRIPTION
The Ox controller was not invoking the programmer-supplied handler
when switches disconnect.