### PR TITLE
polished symbolic automata interface (for @Jaxan)

### DIFF
--- a/examples/automata/README.md
+++ b/examples/automata/README.md
@@ -1,0 +1,30 @@
+# Symbolic NetKAT Automata
+This directory contains NetKAT programs with interesting automata representations. (For more examples, consult the examples/global/ directory.)
+
+## Requirements
+You need graphviz:
+  * MacOS: `brew install graphviz`
+  * Ubuntu: `apt get install graphviz`
+
+The frenetic executable must be installed:
+  * run `make && make reinstall` in the frenetic root directory
+
+## Run
+To convert a NetKAT program into a symbolic NetKAT automaton, run
+```bash
+frenetic dump auto <file>
+```
+This will produce a .dot file named `foo.kat.auto.dot`, if `foo.kat` is the name of the input file.
+
+You can then use graphviz to visualize the .dot file:
+```bash
+dot -Tsvg <.dot-file> -O  # create svg vector graphic
+dot -Tpng <.dot-file> -O  # or, create png file
+```
+
+## Options
+Run `frenetic dump help auto` to see a list of all options. Currently, two flags are supported:
+  * --determinize: determinize the automaton using powerset construction
+  * --minimize: (heuristically) minimize the automaton
+By default, the automaton is neither minimized nor determinized.
+

--- a/examples/automata/unrollable.kat
+++ b/examples/automata/unrollable.kat
@@ -1,0 +1,7 @@
+(* NetKAT automata have the strange property that they can sometimes be unrolled
+   into a loop-free automaton. This is an example for such an automaton.
+*)
+
+vlanId:=0;
+(dup; (filter vlanId=0; vlanId:=1 + filter vlanId=1; vlanId:=2))*;
+filter vlanId=1

--- a/examples/automata/unrolled.kat
+++ b/examples/automata/unrolled.kat
@@ -1,0 +1,8 @@
+(* NetKAT automata have the strange property that they can sometimes be unrolled
+   into a loop-free automaton.
+   This is the unrolled version of the "unrollable.kat" automaton.
+*)
+
+vlanId:=0;
+dup; filter vlanId=0; vlanId:=1;
+filter vlanId=1

--- a/frenetic/Dump.ml
+++ b/frenetic/Dump.ml
@@ -26,7 +26,7 @@ let dump_fdd fdd ~file =
   dump ~file (Frenetic_NetKAT_Compiler.to_dot fdd)
 
 let dump_auto auto ~file =
-  dump ~file (Frenetic_NetKAT_Compiler.Automaton.to_dot auto)
+  dump ~file (Frenetic_NetKAT_Compiler.Automaton.to_dot' auto)
 
 let print_table fdd sw =
   Frenetic_NetKAT_Compiler.to_table sw fdd
@@ -266,9 +266,10 @@ module Auto = struct
 
   let run file json printorder () =
     let pol = parse_pol ~json file in
-    let (t, auto) = time (fun () -> Frenetic_NetKAT_Compiler.Automaton.of_policy pol) in
+    let open Frenetic_NetKAT_Compiler in
+    let (t, auto) = time (fun () -> Automaton.of_policy pol ~dedup:false ~cheap_minimize:false) in
     if printorder then print_order ();
-    dump_auto auto ~file:(file ^ "auto.dot");
+    dump_auto auto ~file:(file ^ ".auto.dot");
     print_time t;
 
 end

--- a/frenetic/Dump.ml
+++ b/frenetic/Dump.ml
@@ -138,12 +138,12 @@ module Flag = struct
       ~doc: "file Physical egress predicate. If not specified, defaults to peg.kat"
 
   let determinize =
-    flag "--determinize" (optional_with_default false bool)
-      ~doc:"bool Determinize automaton."
+    flag "--determinize" no_arg
+      ~doc:"Determinize automaton."
 
   let minimize =
-    flag "--minimize" (optional_with_default false bool)
-      ~doc:"bool Minimize automaton (heuristically)."
+    flag "--minimize" no_arg
+      ~doc:"Minimize automaton (heuristically)."
 end
 
 

--- a/lib/Frenetic_Fdd.ml
+++ b/lib/Frenetic_Fdd.ml
@@ -170,6 +170,7 @@ module Field = struct
       | Star p -> k (f_union p env, lst)
       | Link (sw,pt,_,_) -> k (1, (env, Test (Switch sw)) :: (env, Test (Location (Physical pt))) :: lst)
       | VLink (sw,pt,_,_) -> k (1, (env, Test (VSwitch sw)) :: (env, Test (VPort pt)) :: lst)
+      | Dup -> k (1, lst)
     and f_seq pol env : int =
       let (size, preds) = f_seq' pol [] env (fun x -> x) in
       List.iter preds ~f:(f_pred size);
@@ -188,6 +189,7 @@ module Field = struct
       | Star p -> f_union' p lst env k
       | Link (sw,pt,_,_) -> k (1, (env, Test (Switch sw)) :: (env, Test (Location (Physical pt))) :: lst)
       | VLink (sw,pt,_,_) -> k (1, (env, Test (VSwitch sw)) :: (env, Test (VPort pt)) :: lst)
+      | Dup -> k (1, lst)
     and f_union pol env : int =
       let (size, preds) = f_union' pol [] env (fun x -> x) in
       List.iter preds ~f:(f_pred size);

--- a/lib/Frenetic_Fdd.mli
+++ b/lib/Frenetic_Fdd.mli
@@ -205,6 +205,8 @@ module Action : sig
 
     (** [to_hvs s] converts to a sequence to an HVS list, removing K pseudo-field *)
     val to_hvs : Value.t t -> (Field.t * Value.t) list
+
+    val to_string : Value.t t -> string
   end
 
   module Par : sig
@@ -217,6 +219,8 @@ module Action : sig
     val mod_k : t -> t
     val compare_mod_k : t -> t -> int
     val equal_mod_k : t -> t -> bool
+
+    val to_string : t -> string
   end
 
 

--- a/lib/Frenetic_NetKAT.ml
+++ b/lib/Frenetic_NetKAT.ml
@@ -67,6 +67,7 @@ type policy =
      https://github.com/janestreet/ppx_sexp_conv/issues/9 *)
   (* | Let of { id : metaId; init : meta_init; body : policy; mut : bool } *)
   | Let of metaId * meta_init * bool * policy
+  | Dup
   [@@deriving sexp]
 
 let id = Filter True

--- a/lib/Frenetic_NetKAT.mli
+++ b/lib/Frenetic_NetKAT.mli
@@ -80,6 +80,7 @@ type policy =
      https://github.com/janestreet/ppx_sexp_conv/issues/9 *)
   (* | Let of { id : metaId; init : meta_init; body : policy; mut : bool } *)
   | Let of metaId * meta_init * bool * policy
+  | Dup
   [@@deriving sexp]
 
 val id : policy

--- a/lib/Frenetic_NetKAT_Compiler.ml
+++ b/lib/Frenetic_NetKAT_Compiler.ml
@@ -835,7 +835,7 @@ module Automaton = struct
     (* auxillary functions *)
     let rec do_states () =
       fprintf fmt "# put state nodes on top\n";
-      fprintf fmt "{rank=source; shape = box;";
+      fprintf fmt "{rank=source;";
       List.iter (Hashtbl.keys states) ~f:(fprintf fmt " %a" state_lbl);
       fprintf fmt ";}@\n";
       (* -- *)
@@ -892,13 +892,14 @@ module Automaton = struct
       Buffer.contents buf
     end
 
+end
+(* END: module Automaton *)
+
 
 let compile_global ?(options=default_compiler_options) ?(pc=Field.Vlan) pol : FDD.t =
   prepare_compilation ~options pol;
   Automaton.of_policy pol
   |> Automaton.to_local ~pc
-
-
 
 
 

--- a/lib/Frenetic_NetKAT_Compiler.ml
+++ b/lib/Frenetic_NetKAT_Compiler.ml
@@ -119,7 +119,7 @@ module FDD = struct
     | Let (field, init, mut, p) ->
       let env = Field.Env.add env field init mut in
       of_local_pol_k env p (fun p' -> k (erase env p' field init))
-    | Link _ | VLink _ -> raise Non_local
+    | Link _ | VLink _ | Dup -> raise Non_local
 
   let rec of_local_pol ?(env=Field.Env.empty) p = of_local_pol_k env p ident
 
@@ -540,12 +540,13 @@ module Pol = struct
           |> mk_filter in
       mk_big_seq [filter_vloc s1 p1; Dup; link; Dup; post_link]
     | Let _ -> failwith "meta fields not supported by global compiler yet"
+    | Dup -> Dup
 end
 
 
 
-(* Symbolic NetKAT Automata *)
-module NetKAT_Automaton = struct
+(* Symbolic NetKAT Automata (intermediate representation of global compiler) *)
+module Automaton = struct
 
   (* table *)
   module Tbl = Int.Table
@@ -884,8 +885,8 @@ end
 
 let compile_global ?(options=default_compiler_options) ?(pc=Field.Vlan) pol : FDD.t =
   prepare_compilation ~options pol;
-  NetKAT_Automaton.of_policy pol
-  |> NetKAT_Automaton.to_local ~pc
+  Automaton.of_policy pol
+  |> Automaton.to_local ~pc
 
 
 

--- a/lib/Frenetic_NetKAT_Compiler.ml
+++ b/lib/Frenetic_NetKAT_Compiler.ml
@@ -840,7 +840,7 @@ module Automaton = struct
       fprintf fmt ";}@\n";
       (* -- *)
       fprintf fmt "\n# mark start state\n";
-      fprintf fmt "%a [style=bold, color=red];@\n" state_lbl automaton.source;
+      fprintf fmt "%a [style=bold, color=red, shape=octagon];@\n" state_lbl automaton.source;
       (* -- *)
       fprintf fmt "\n# connect state nodes to FDDs\n";
       Hashtbl.iteri states ~f:(fun ~key:id ~data:fdd ->
@@ -868,8 +868,7 @@ module Automaton = struct
         do_fdds seen (a::b::worklist)
       | Leaf par ->
         fprintf fmt "subgraph cluster_%a {@\n" fdd_lbl fdd;
-        fprintf fmt "\trank = sink;@\n" ;
-        fprintf fmt "\tshape = box;@\n" ;
+        fprintf fmt "\trank=sink;@\n";
         fprintf fmt "\t%a [shape = point];@\n" fdd_lbl fdd;
         let transitions = List.mapi (Action.Par.to_list par) ~f:(do_seq fdd) in
         fprintf fmt "}@\n";

--- a/lib/Frenetic_NetKAT_Compiler.ml
+++ b/lib/Frenetic_NetKAT_Compiler.ml
@@ -455,6 +455,7 @@ let options_to_json_string opt =
   ] |> pretty_to_string
 
 
+
 (*==========================================================================*)
 (* GLOBAL COMPILATION                                                       *)
 (*==========================================================================*)
@@ -822,73 +823,80 @@ module Automaton = struct
       let fdd = FDD.seq guard (FDD.union e d) in
       FDD.union acc fdd)
 
-  (* SJS: horrible hack *)
   let to_dot (automaton : t) =
-    let states = Tbl.map automaton.states ~f:(fun (e,d) -> FDD.union e d) in
     let open Format in
     let buf = Buffer.create 200 in
     let fmt = formatter_of_buffer buf in
-    let seen = FDD.Tbl.create () ~size:20 in
-    pp_set_margin fmt (1 lsl 29);
-    fprintf fmt "digraph fdd {@\n";
-    let rec node_loop node =
-      if not (FDD.Tbl.mem seen node) then begin
-        FDD.Tbl.add_exn seen node ();
-        match FDD.unget node with
-        | Leaf par ->
-          let node = (node : FDD.t :> int) in
-          let seqId = ref 0 in
-          let edges = ref [] in
-          fprintf fmt "subgraph cluster_%d {@\n" node;
-          fprintf fmt "\trank = sink;@\n" ;
-          fprintf fmt "\tshape = box;@\n" ;
-          fprintf fmt "\t%d [shape = point];@\n" node;
-          Action.Par.iter par ~f:(fun seq ->
-            let id : string = sprintf "\"%dS%d\"" node (!seqId) in
-            let cont = Action.Seq.find seq K
-              |> Option.map ~f:(fun v -> Tbl.find_exn states (Value.to_int_exn v)) in
-            let label = Action.to_string (Action.Par.singleton seq) in
-            fprintf fmt "\t%s [shape=box, label=\"%s\"];@\n" id label;
-            Option.iter cont ~f:(fun k ->
-              edges := sprintf "%s -> %d [style=bold, color=blue];@\n"
-                id (k : FDD.t :> int) :: (!edges));
-            incr seqId;
-          );
-          fprintf fmt "}@\n";
-          List.iter (!edges) ~f:(fprintf fmt "%s")
-        | Branch((f, v), a, b) ->
-          let node = (node : FDD.t :> int) in
-          fprintf fmt "%d [label=\"%s = %s\"];@\n" node (Field.to_string f) (Value.to_string v);
-          fprintf fmt "%d -> %d;@\n" node (a : FDD.t :> int);
-          fprintf fmt "%d -> %d [style=\"dashed\"];@\n" node (b : FDD.t :> int);
-          node_loop a;
-          node_loop b
-      end
-    in
-    let fdds = ref [] in
-    let rec fdd_loop fddId =
-      let fdd = Tbl.find_exn states fddId in
-      let conts = FDD.conts fdd in
-      fdds := fdd :: (!fdds);
-      node_loop fdd;
-      Set.iter conts ~f:fdd_loop
-    in
-    fdd_loop automaton.source;
-    fprintf fmt "%d [style=bold, color=red];@\n"
-      (Tbl.find_exn states automaton.source : FDD.t :> int);
-    fprintf fmt "{rank=source; ";
-    List.iter (!fdds) ~f:(fun fdd -> fprintf fmt "%d " (fdd : FDD.t :> int));
-    fprintf fmt ";}@\n";
-    fprintf fmt "}@.";
-    Buffer.contents buf
-end
+    let states = Hashtbl.map automaton.states ~f:(fun (e,d) -> FDD.union e d) in
+    let state_lbl fmt = fprintf fmt "state_%d" in
+    let fdd_lbl fmt fdd = fprintf fmt "fdd_%d" (fdd : FDD.t :> int) in
+    let fdd_leaf_lbl fmt (i,fdd) = fprintf fmt "seq_%d_%d" (fdd : FDD.t :> int) i in
+
+    (* auxillary functions *)
+    let rec do_states () =
+      fprintf fmt "# put state nodes on top\n";
+      fprintf fmt "{rank=source; shape = box;";
+      List.iter (Hashtbl.keys states) ~f:(fprintf fmt " %a" state_lbl);
+      fprintf fmt ";}@\n";
+      (* -- *)
+      fprintf fmt "\n# mark start state\n";
+      fprintf fmt "%a [style=bold, color=red];@\n" state_lbl automaton.source;
+      (* -- *)
+      fprintf fmt "\n# connect state nodes to FDDs\n";
+      Hashtbl.iteri states ~f:(fun ~key:id ~data:fdd ->
+        fprintf fmt "%a -> %a;@\n" state_lbl id fdd_lbl fdd);
+      (* -- *)
+      fprintf fmt "\n# define FDDs\n";
+      do_fdds Int.Set.empty (Hashtbl.data states)
+
+    and do_fdds seen worklist =
+      match worklist with
+      | [] -> ()
+      | fdd::worklist ->
+        let uid = (fdd : FDD.t :> int) in
+        if Set.mem seen uid then 
+          do_fdds seen worklist 
+        else
+          do_node (Set.add seen uid) worklist fdd
+
+    and do_node seen worklist fdd =
+      match FDD.unget fdd with
+      | Branch((f, v), a, b) ->
+        fprintf fmt "%a [label=\"%s = %s\"];\n" fdd_lbl fdd (Field.to_string f) (Value.to_string v);
+        fprintf fmt "%a -> %a;\n" fdd_lbl fdd fdd_lbl a;
+        fprintf fmt "%a -> %a [style=\"dashed\"];\n" fdd_lbl fdd fdd_lbl b;
+        do_fdds seen (a::b::worklist)
+      | Leaf par ->
+        fprintf fmt "subgraph cluster_%a {@\n" fdd_lbl fdd;
+        fprintf fmt "\trank = sink;@\n" ;
+        fprintf fmt "\tshape = box;@\n" ;
+        fprintf fmt "\t%a [shape = point];@\n" fdd_lbl fdd;
+        let transitions = List.mapi (Action.Par.to_list par) ~f:(do_seq fdd) in
+        fprintf fmt "}@\n";
+        List.iter transitions ~f:(function 
+          | None -> () 
+          | Some (s,t) ->
+            fprintf fmt "%a -> %a [style=bold, color=blue];@\n" fdd_leaf_lbl s state_lbl t);
+        do_fdds seen worklist
+
+    and do_seq fdd i seq =
+      let label = Action.Seq.to_string seq in
+      fprintf fmt "\t%a [shape=box, label=\"%s\"];@\n" fdd_leaf_lbl (i,fdd) label;
+      Option.map (Action.Seq.find seq K) ~f:(fun v -> 
+        ((i, fdd), Value.to_int_exn v))
+    
+    in begin
+      fprintf fmt "digraph automaton {@\n";
+      do_states ();
+      fprintf fmt "}@.";
+      Buffer.contents buf
+    end
+
 
 let compile_global ?(options=default_compiler_options) ?(pc=Field.Vlan) pol : FDD.t =
   prepare_compilation ~options pol;
   Automaton.of_policy pol
   |> Automaton.to_local ~pc
-
-
 
 
 

--- a/lib/Frenetic_NetKAT_Compiler.mli
+++ b/lib/Frenetic_NetKAT_Compiler.mli
@@ -30,7 +30,6 @@ module Automaton : sig
   val to_local: pc:Field.t -> t -> FDD.t
 
   val to_dot: t -> string
-  val to_dot' : t -> string
 end
 
 type cache

--- a/lib/Frenetic_NetKAT_Compiler.mli
+++ b/lib/Frenetic_NetKAT_Compiler.mli
@@ -16,7 +16,8 @@ type t = FDD.t
 
 val to_dot : t -> string
 
-module NetKAT_Automaton : sig
+(** Intermediate representation of global compiler: NetKAT Automata *)
+module Automaton : sig
   type t
 
   val fold_reachable: ?order:[< `Post | `Pre > `Pre ]

--- a/lib/Frenetic_NetKAT_Compiler.mli
+++ b/lib/Frenetic_NetKAT_Compiler.mli
@@ -30,6 +30,7 @@ module Automaton : sig
   val to_local: pc:Field.t -> t -> FDD.t
 
   val to_dot: t -> string
+  val to_dot' : t -> string
 end
 
 type cache

--- a/lib/Frenetic_NetKAT_Json.ml
+++ b/lib/Frenetic_NetKAT_Json.ml
@@ -120,6 +120,7 @@ let rec policy_to_json (pol : policy) : json = match pol with
             ("sw2", `Int (Int64.to_int_exn sw2));
             ("pt2", `Int (Int64.to_int_exn pt2))]
   | Let _ -> failwith "meta fields not supported yet"
+  | Dup -> failwith "dup not supported"
 
 
 (** From JSON **)

--- a/lib/Frenetic_NetKAT_Lexer.ml
+++ b/lib/Frenetic_NetKAT_Lexer.ml
@@ -85,6 +85,7 @@ let token ~ppx ~loc_start buf =
   | "pipe" -> PIPE
   | "query" -> QUERY
   | '"', Star (Compl '"'), '"' -> STRING (ascii ~skip:1 ~drop:1 buf)
+  | "dup" -> DUP
   (* antiquotations *)
   | '$', id ->
     if ppx then

--- a/lib/Frenetic_NetKAT_Optimize.ml
+++ b/lib/Frenetic_NetKAT_Optimize.ml
@@ -104,7 +104,7 @@ let specialize_policy sw pol =
         loop pol (fun p -> k (mk_star p))
       | Let (id, init, mut, pol) ->
         loop pol (fun p -> k (Let (id, init, mut, p)))
-      | Link _ | VLink _ ->
+      | Link _ | VLink _ | Dup ->
         failwith "cannot specialize global policy" in
   loop pol (fun x -> x)
 
@@ -159,6 +159,7 @@ let rec norm_policy (pol : policy) : policy = match pol with
     mk_big_seq (list_of_seq pol')
   | Let (id, init, mut, pol) ->
     Let (id, init, mut, norm_policy pol)
+  | Dup -> Dup
 
 (*
    TODO(car): flatten_union in Optimize outputs the unioned policies in reverse order.  While this is semantically equivalent,

--- a/lib/Frenetic_NetKAT_Pretty.ml
+++ b/lib/Frenetic_NetKAT_Pretty.ml
@@ -115,6 +115,7 @@ module Formatting = struct
       | VLink (vsw,vpt,vsw',vpt') ->
         fprintf fmt "@[%Lu@@%Lu =>>@ %Lu@@%Lu@]"
           vsw vpt vsw' vpt'
+      | Dup -> fprintf fmt "@[dup@]"
 end
   
 let format_policy = Formatting.pol Formatting.PAREN
@@ -126,10 +127,11 @@ let string_of_policy = Frenetic_Util.make_string_of format_policy
 let string_of_pred = Frenetic_Util.make_string_of format_pred
 
 let rec pretty_assoc (p : policy) : policy = match p with
-  | Filter _ -> p
-  | Mod _ -> p
-  | Link _ -> p
-  | VLink _ -> p
+  | Filter _
+  | Mod _
+  | Link _
+  | VLink _ 
+  | Dup -> p
   | Union (p1, p2) -> pretty_assoc_par p
   | Seq (p1, p2) -> pretty_assoc_seq p
   | Star p' -> Star (pretty_assoc p')

--- a/lib/Parser.cppo.mly
+++ b/lib/Parser.cppo.mly
@@ -33,6 +33,7 @@ let int64 ?loc ?attrs x =
 %token TRUE FALSE AND OR NOT EQUALS
 %token ID DROP FILTER ASSIGN SEMICOLON PLUS STAR LINK VLINK AT SLASH
 %token IF THEN ELSE WHILE DO
+%token DUP
 
 (* fields *)
 %token SWITCH PORT VSWITCH VPORT VFABRIC ETHSRC ETHDST VLAN VLANPCP ETHTYPE IPPROTO IP4SRC IP4DST TCPSRCPORT TCPDSTPORT
@@ -88,6 +89,8 @@ pol:
   | ID
       AST( id )
       PPX( id )
+  | DUP
+      BOTH( id )
   | FILTER; a=pred
       AST( Filter a )
       PPX( Filter [%e a] )

--- a/lib/Parser.cppo.mly
+++ b/lib/Parser.cppo.mly
@@ -90,7 +90,7 @@ pol:
       AST( id )
       PPX( id )
   | DUP
-      BOTH( id )
+      BOTH( Dup )
   | FILTER; a=pred
       AST( Filter a )
       PPX( Filter [%e a] )


### PR DESCRIPTION
* extends `frenetic dump` with a command to dump automata
* exposes `dup` in NetKAT source language, to allow experimenting with automata more easily.
* fixes & improves pretty printing of symbolic NetKAT automata
* add directory for automata examples