### PR TITLE
Portless NetKAT

### DIFF
--- a/lib/async/OpenFlow0x01_Plugin.ml
+++ b/lib/async/OpenFlow0x01_Plugin.ml
@@ -231,7 +231,8 @@ let action_from_policy (pol:Frenetic_netkat.Syntax.policy) : action option =
         Some (Modify(SetTCPSrcPort tpPort))
       | TCPDstPort tpPort ->
         Some (Modify(SetTCPDstPort tpPort))
-      | Switch _ | VSwitch _ | VPort _ | VFabric _ | Meta _ -> None
+      | Switch _ | VSwitch _ | VPort _ | VFabric _ | Meta _
+      | From _ | AbstractLoc _ -> None
     end
   | _ -> None
 

--- a/lib/base/std/Topology.ml
+++ b/lib/base/std/Topology.ml
@@ -50,3 +50,110 @@ let edge (t: Net.Topology.t) =
         | Some _ -> acc)
     | _ -> acc)
   t []
+
+module Mininet = struct
+
+  type location =
+    | Switch of int * int
+    | Host of int
+
+  let geo_sum a r n = a * ((1 - (Int.pow r n)) / (1 - r))
+
+  let (--) i j =
+    let rec aux n acc = if n < i then acc else aux (n-1) (n :: acc)
+    in aux j []
+
+  let single host_count =
+    let children = 1 -- host_count in
+    let topo_down, _ = List.fold children ~init:([], 1)
+        ~f:(fun (acc, port) to_host ->
+            ((Switch(1, port), Host(to_host)) :: acc), port + 1) in
+    let topo_up = List.map topo_down (fun (x, y) -> y, x) in
+    topo_up @ topo_down
+
+  let minimal = single 2
+
+  let linear switch_count =
+    let hosts = List.map (1 -- switch_count) (fun x -> (Switch(x, 1), Host(x))) in
+    let switches =
+      if switch_count > 1 then
+        (Switch(2, 2), Switch(1, 2)) :: List.map (2 -- (switch_count - 1)) (fun x -> (Switch((x + 1), 2), Switch(x, 3)))
+      else
+        [] in
+    let topo_down = hosts @ switches in
+    let topo_up = List.map topo_down (fun (x, y) -> y, x) in
+    topo_up @ topo_down
+
+  let tree depth fanout =
+    let rec add_hosts switch fanout position =
+      let children = (((position - 1) * fanout) + 1) -- (position * fanout) in
+      let switches, top_port = List.fold children ~init:([], 1)
+          ~f:(fun (acc, port) to_host ->
+              ((Switch(switch, port), Host(to_host)) :: acc), port + 1)
+      in switches in
+    let rec add_switches switch fanout =
+      let children = (((switch - 1) * fanout) + 2) -- ((switch * fanout) + 1) in
+      let switches, top_port = List.fold children ~init:([], 1)
+          ~f:(fun (acc, port) to_sw ->
+              ((Switch(switch, port), Switch(to_sw, (fanout + 1))) :: acc), port + 1)
+      in switches in
+    let switch_numbers    = 1 -- (geo_sum 1 fanout (depth - 1)) in
+    let switch_with_hosts = List.zip_exn
+        (((geo_sum 1 fanout (depth - 1)) + 1) -- (geo_sum 1 fanout depth))
+        (1 -- (Int.pow fanout (depth - 1))) in
+    let sw_links = List.fold switch_numbers ~init:[] ~f:(fun acc sw -> add_switches sw fanout @ acc) in
+    let topo_down = List.fold switch_with_hosts ~init:sw_links ~f:(fun acc (sw, pos) -> add_hosts sw fanout pos @ acc) in
+    let topo_up = List.map topo_down (fun (x, y) -> y, x) in
+    topo_up @ topo_down
+
+  let location_tuples_to_topology location_tuples =
+    let location_to_id loc = match loc with
+      | Switch (id, port) -> Network.Node.Switch, id
+      | Host id -> Network.Node.Host, id in
+
+    (* Get all unique locations *)
+    let locations = List.dedup (List.fold location_tuples ~init:[]
+        ~f:(fun acc (x, y) -> location_to_id x :: location_to_id y :: acc)) in
+
+    (* Get a topology with all vertices *)
+    let topo_with_vertexes, loc_tup_to_vertex_table = List.fold locations ~init:(Network.Net.Topology.empty (), [])
+        ~f:(fun (old_topo, acc) loc ->
+            let device, id = loc in
+            let name, ip, mac = match device with
+              | Network.Node.Switch -> "s" ^ (Int.to_string id), 0l, 0L
+              | Network.Node.Host -> "h" ^ (Int.to_string id), Int32.(of_int_exn id + 167772160l), Int64.of_int id
+              | Network.Node.Middlebox -> "m" ^ (Int.to_string id), 0l, 0L in
+            let vertex_node = Network.Node.create name (Int64.of_int id) device ip mac in
+            let topo, vertex = Network.Net.Topology.add_vertex old_topo vertex_node in
+            (topo, (loc, vertex) :: acc)) in
+
+    (* Function to find a vertex from location *)
+    let find_vertex loc = List.Assoc.find_exn loc_tup_to_vertex_table ~equal:(=)
+        (location_to_id loc) in
+
+    (* Add all the edges to the topo *)
+    List.fold location_tuples ~init:topo_with_vertexes ~f:(fun old_topo (from_loc, to_loc) ->
+        let loc_to_port loc = match loc with
+          | Switch (id, port)-> Int32.of_int_exn port
+          | Host id -> 1l in
+        let topo, _ = Network.Net.Topology.add_edge old_topo
+            (find_vertex from_loc) (loc_to_port from_loc)
+            (Network.Link.default)
+            (find_vertex to_loc) (loc_to_port to_loc) in
+        topo)
+
+  type topo_name =
+    | Tree of int * int
+    | Linear of int
+    | Single of int
+    | Minimal
+
+  let topo_from_name name =
+    (match name with
+      | Tree (x, y) -> tree x y
+      | Linear x -> linear x
+      | Single x -> single x
+      | Minimal -> minimal)
+    |> location_tuples_to_topology
+
+end

--- a/lib/base/std/Topology.mli
+++ b/lib/base/std/Topology.mli
@@ -15,3 +15,13 @@ val internal_ports : Net.Topology.t -> SDN.switchId -> Net.Topology.PortSet.t
 val in_edge : Net.Topology.t -> SDN.switchId -> SDN.portId -> bool
 
 val edge : Net.Topology.t -> (SDN.switchId * SDN.portId) list
+
+module Mininet: sig
+  type topo_name =
+    | Tree of int * int
+    | Linear of int
+    | Single of int
+    | Minimal
+
+  val topo_from_name: topo_name -> Network.Net.Topology.t
+end

--- a/lib/netkat/Fdd.mli
+++ b/lib/netkat/Fdd.mli
@@ -34,6 +34,8 @@ module Field : sig
   type t
     = Switch
     | Location
+    | From
+    | AbstractLoc
     | VSwitch
     | VPort
     | Vlan
@@ -128,6 +130,7 @@ module Value : sig
   type t =
       Const of Int64.t
     | Mask of Int64.t * int
+    | AbstractLocation of string
     | Pipe of string
     | Query of string
     (* TODO(grouptable): HACK, should only be able to fast fail on ports.

--- a/lib/netkat/Json.ml
+++ b/lib/netkat/Json.ml
@@ -38,6 +38,8 @@ let from_json_ip (json : json) : Frenetic_base.Packet.nwAddr * int32 =
 let to_json_value (h : header_val) : json = match h with
   | Switch n | VSwitch n | VPort n | VFabric n -> `String (string_of_int (Int64.to_int_exn n))
   (* JavaScript can't represent large 64-bit numbers *)
+  | From loc | AbstractLoc loc ->
+    `String (Core.Sexp.to_string (sexp_of_abstract_location loc))
   | EthSrc n
   | EthDst n -> `String (string_of_mac n)
   | Location (Physical n) -> `Assoc [("type", `String "physical");
@@ -63,6 +65,8 @@ let to_json_header (h : header_val) : json =
   let str = match h with
     | Switch _ -> "switch"
     | Location _ -> "location"
+    | From _ -> "from"
+    | AbstractLoc _ -> "abstractloc"
     | EthSrc _ -> "ethsrc"
     | EthDst _ -> "ethdst"
     | Vlan _ -> "vlan"

--- a/lib/netkat/Lexer.cppo.sedlex.ml
+++ b/lib/netkat/Lexer.cppo.sedlex.ml
@@ -164,6 +164,9 @@ let token ~ppx ~loc_start buf =
   | "ip4Dst" -> IP4DST
   | "tcpSrcPort" -> TCPSRCPORT
   | "tcpDstPort" -> TCPDSTPORT
+  (* portless *)
+  | "from" -> FROM
+  | "loc" -> ABSTRACTLOC
   (* syntax sugar *)
   | "if" -> IF
   | "then" -> THEN

--- a/lib/netkat/Parser.ml
+++ b/lib/netkat/Parser.ml
@@ -1,16 +1,23 @@
 (** Thin wrapper around Menhir-generated parser, providing a saner interface. *)
 
-module Lexer = Lexer
-module Parser = Generated_Parser
+module MAKE(Lexer : module type of Lexer)
+    (Parser : module type of Generated_Parser) = struct
 
-let pol_of_string ?pos (s : string) =
-  Lexer.parse_string ?pos s Parser.pol_eof
+  let pol_of_string ?pos (s : string) =
+    Lexer.parse_string ?pos s Parser.pol_eof
 
-let pred_of_string ?pos (s : string) =
-  Lexer.parse_string ?pos s Parser.pred_eof
+  let pred_of_string ?pos (s : string) =
+    Lexer.parse_string ?pos s Parser.pred_eof
 
-let pol_of_file (file : string) =
-  Lexer.parse_file ~file Parser.pol_eof
+  let pol_of_file (file : string) =
+    Lexer.parse_file ~file Parser.pol_eof
 
-let pred_of_file (file : string) =
-  Lexer.parse_file ~file Parser.pred_eof
+  let pred_of_file (file : string) =
+    Lexer.parse_file ~file Parser.pred_eof
+
+end
+
+include MAKE(Lexer)(Generated_Parser)
+
+(** portless extensions *)
+module Portless = MAKE(Lexer)(Portless_Generated_Parser)

--- a/lib/netkat/Parser.mli
+++ b/lib/netkat/Parser.mli
@@ -5,3 +5,11 @@ val pred_of_string : ?pos: Lexing.position -> string -> Syntax.pred
 
 val pol_of_file : string -> Syntax.policy
 val pred_of_file : string -> Syntax.pred
+
+module Portless : sig
+  val pol_of_string : ?pos: Lexing.position -> string -> Syntax.policy
+  val pred_of_string : ?pos: Lexing.position -> string -> Syntax.pred
+
+  val pol_of_file : string -> Syntax.policy
+  val pred_of_file : string -> Syntax.pred
+end

--- a/lib/netkat/Portless_Compiler.ml
+++ b/lib/netkat/Portless_Compiler.ml
@@ -1,0 +1,122 @@
+open Core
+open Syntax
+
+module Network = Frenetic_base.Network
+module Net = Network.Net
+module Topology = Net.Topology
+
+type direction = Incoming | Outgoing
+type topo = (abstract_location, Topology.vertex) Hashtbl.t * Topology.t
+
+let connected_switches ~loc ~direction ~topo =
+  let (name_to_vertex_table, network) = topo in
+  let vertex = Hashtbl.find name_to_vertex_table loc in
+  match vertex with
+  | None -> failwith "no such location"
+  | Some loc ->
+    let neighbors = Topology.neighbors network loc in
+    Topology.VertexSet.fold neighbors ~init:[] ~f:(fun acc other ->
+        let node = Topology.vertex_to_label network other in
+        if Network.Node.device node = Switch then
+          let edges = match direction with
+            | Incoming -> Topology.find_all_edges network other loc
+            | Outgoing -> Topology.find_all_edges network loc other in
+          Topology.EdgeSet.fold edges ~init:acc ~f:(fun acc edge ->
+              let v, port =  match direction with
+                | Incoming -> Topology.edge_src edge
+                | Outgoing -> Topology.edge_dst edge in
+              (Network.Node.id (Topology.vertex_to_label network other), port) :: acc)
+        else
+          acc)
+
+let abs_loc_to_switch (topo: topo) loc =
+  let (name_to_vertex_table, network) = topo in
+  let vertex = Hashtbl.find name_to_vertex_table loc in
+  match vertex with
+  | Some v ->
+    let node = (Topology.vertex_to_label network v) in
+    if Network.Node.device node = Switch then
+      Network.Node.id node
+    else
+      failwith "the location is not a switch"
+  | None -> failwith "no such location"
+
+let is_loc_host (topo: topo) loc =
+  let (name_to_vertex_table, network) = topo in
+  let vertex = Hashtbl.find name_to_vertex_table loc in
+  match vertex with
+  | Some v -> Network.Node.device (Topology.vertex_to_label network v) = Host
+  | None -> failwith "no such location"
+
+
+let portify_pred pred (topo: topo) =
+  let rec portify_pred' pred (k: pred -> pred) =
+    match pred with
+    | True -> k True
+    | False -> k False
+    | And (pred1, pred2) ->
+      portify_pred' pred1 (fun x ->
+          portify_pred' pred2 (fun y ->
+              k (And (x, y))))
+    | Or (pred1, pred2) ->
+      portify_pred' pred1 (fun x ->
+          portify_pred' pred2 (fun y ->
+              k (Or (x, y))))
+    | Neg pred ->
+      portify_pred' pred (fun x -> k (Neg x))
+    | Test header -> match header with
+      | AbstractLoc loc -> k (Test (Switch (abs_loc_to_switch topo loc)))
+      | From loc ->
+        let from_list = connected_switches loc Incoming topo in
+        List.fold from_list
+          ~init:(False)
+          ~f:(fun acc (sw, pt) ->
+              k (Or (acc, And (
+                  (Test (Switch sw)),
+                  (Test (Location (Physical pt)))))))
+      | Switch _ | Location _ -> failwith "cannot specify switch and port for portless policies"
+      | x -> k (Test x) in
+  portify_pred' pred (fun x -> x)
+
+let portify_pol_fdd (portless_pol_fdd: Compiler.t) (topo: topo): policy =
+  let rec portify_pol' portless_pol k =
+    match portless_pol with
+    | Union (pol1, pol2) ->
+      portify_pol' pol1 (fun x ->
+          portify_pol' pol2 (fun y ->
+              k (Union (x, y))))
+    | Seq (pol1, pol2) ->
+      portify_pol' pol1 (fun x ->
+          portify_pol' pol2 (fun y ->
+              k (Seq (x, y))))
+    | Star pol -> portify_pol' pol (fun x -> k (Star x))
+    | Filter pred -> k (Filter (portify_pred pred topo))
+    | Let meta -> portify_pol' meta.body (fun x -> k (Let {meta with body = x}))
+    | Dup -> k Dup
+    | Link _ | VLink _ -> failwith "links not supported for portless policies"
+    | Mod header -> match header with
+      | AbstractLoc loc ->
+        let sw_port_list = connected_switches loc Outgoing topo in
+        k (List.fold sw_port_list
+             ~init:(if is_loc_host topo loc then drop else Filter (Test (Switch (abs_loc_to_switch topo loc))))
+             ~f:(fun acc (sw, mod_pt) ->
+                 let portful_test = Test (Switch sw) in
+                 let portful_mod = Mod (Location (Physical mod_pt)) in
+                 Union (acc, Seq (Filter portful_test, portful_mod))))
+      | From loc -> k id
+      | Switch _ | Location _ -> failwith "cannot specify switch and port for portless policies"
+      | x -> k (Mod x) in
+  let portless_pol = Compiler.to_local_pol portless_pol_fdd in
+  portify_pol' portless_pol (fun x -> x)
+
+let make_topo (network: Topology.t): topo =
+  let name_to_vertex_table = String.Table.create () in
+  Topology.iter_vertexes (fun vertex ->
+      let vertex_name = (Network.Node.name (Topology.vertex_to_label network vertex)) in
+      let _ = Hashtbl.add name_to_vertex_table vertex_name vertex in ()) network;
+  (name_to_vertex_table, network)
+
+let compile portless_pol (network: Topology.t) =
+  let topo = make_topo network in
+  let portless_pol_fdd = Compiler.compile_local portless_pol in
+  portify_pol_fdd portless_pol_fdd topo

--- a/lib/netkat/Portless_Compiler.mli
+++ b/lib/netkat/Portless_Compiler.mli
@@ -1,0 +1,3 @@
+
+(** Compiles a portless policy to a portful policy using the provided topology*)
+val compile: Syntax.policy -> Frenetic_base.Network.Net.Topology.t -> Syntax.policy

--- a/lib/netkat/Pretty.ml
+++ b/lib/netkat/Pretty.ml
@@ -19,7 +19,7 @@ module Formatting = struct
     | Location(Query x) -> fprintf fmt "@[port %s query(\"%s\")@]" asgn x
     | From(l) -> fprintf fmt "@[from %s \"%s\"@]" asgn
                    (Sexp.to_string (sexp_of_abstract_location l))
-    | AbstractLoc(l) -> fprintf fmt "@[from %s \"%s\"@]" asgn
+    | AbstractLoc(l) -> fprintf fmt "@[loc %s \"%s\"@]" asgn
                           (Sexp.to_string (sexp_of_abstract_location l))
     | EthSrc(n) -> fprintf fmt "@[ethSrc %s %s@]" asgn (Frenetic_base.Packet.string_of_mac n)
     | EthDst(n) -> fprintf fmt "@[ethDst %s %s@]" asgn (Frenetic_base.Packet.string_of_mac n)

--- a/lib/netkat/Pretty.ml
+++ b/lib/netkat/Pretty.ml
@@ -1,5 +1,6 @@
 open Syntax
 
+module Sexp = Core.Sexp
 module Formatting = struct
   open Format
 
@@ -16,6 +17,10 @@ module Formatting = struct
     | Location(FastFail n_lst) -> fprintf fmt "@[fastFail ports %s %s@]" asgn (string_of_fastfail n_lst)
     | Location(Pipe x) -> fprintf fmt "@[port %s pipe(\"%s\")@]" asgn x
     | Location(Query x) -> fprintf fmt "@[port %s query(\"%s\")@]" asgn x
+    | From(l) -> fprintf fmt "@[from %s \"%s\"@]" asgn
+                   (Sexp.to_string (sexp_of_abstract_location l))
+    | AbstractLoc(l) -> fprintf fmt "@[from %s \"%s\"@]" asgn
+                          (Sexp.to_string (sexp_of_abstract_location l))
     | EthSrc(n) -> fprintf fmt "@[ethSrc %s %s@]" asgn (Frenetic_base.Packet.string_of_mac n)
     | EthDst(n) -> fprintf fmt "@[ethDst %s %s@]" asgn (Frenetic_base.Packet.string_of_mac n)
     | Vlan(n) -> fprintf fmt "@[vlanId %s %d@]" asgn n

--- a/lib/netkat/Semantics.ml
+++ b/lib/netkat/Semantics.ml
@@ -8,6 +8,8 @@ module HeadersValues = struct
 
   type t =
     { location : location sexp_opaque
+    ; from : abstract_location
+    ; abstractLoc : abstract_location
     ; ethSrc : dlAddr
     ; ethDst : dlAddr
     ; vlan : int16
@@ -35,6 +37,8 @@ module HeadersValues = struct
         | FastFail n_lst -> Printf.sprintf "%s" (string_of_fastfail n_lst)
         | Pipe x     -> Printf.sprintf "pipe(%s)" x
         | Query x    -> Printf.sprintf "query(%s)" x))
+      ~from:(g (fun x -> Core.Sexp.to_string (sexp_of_abstract_location x)))
+      ~abstractLoc:(g (fun x -> Core.Sexp.to_string (sexp_of_abstract_location x)))
       ~ethSrc:Int64.(g to_string)
       ~ethDst:Int64.(g to_string)
       ~vlan:Int.(g to_string)
@@ -54,6 +58,8 @@ module HeadersValues = struct
     Fields.fold
       ~init:[]
       ~location:(conv (fun x -> Location x))
+      ~from:(conv (fun x -> From x))
+      ~abstractLoc:(conv (fun x -> AbstractLoc x))
       ~ethSrc:(conv (fun x -> EthSrc x))
       ~ethDst:(conv (fun x -> EthDst x))
       ~vlan:(conv (fun x -> Vlan x))
@@ -130,6 +136,8 @@ let rec eval_pred (pkt : packet) (pr : pred) : bool = match pr with
       match hv with
       | Switch n -> pkt.switch = n
       | Location l -> pkt.headers.location = l
+      | From l -> pkt.headers.from = l
+      | AbstractLoc l -> pkt.headers.abstractLoc = l
       | EthSrc n -> pkt.headers.ethSrc = n
       | EthDst n -> pkt.headers.ethDst = n
       | Vlan n -> pkt.headers.vlan = n
@@ -162,6 +170,8 @@ let rec eval (pkt : packet) (pol : policy) : PacketSet.t = match pol with
     let pkt' = match hv with
       | Switch n -> { pkt with switch = n }
       | Location l -> { pkt with headers = { pkt.headers with location = l }}
+      | From l -> { pkt with headers = { pkt.headers with from = l }}
+      | AbstractLoc l -> { pkt with headers = { pkt.headers with abstractLoc = l }}
       | EthSrc n -> { pkt with headers = { pkt.headers with ethSrc = n }}
       | EthDst n -> { pkt with headers = { pkt.headers with ethDst = n }}
       | Vlan n -> { pkt with headers = { pkt.headers with vlan = n }}

--- a/lib/netkat/Semantics.mli
+++ b/lib/netkat/Semantics.mli
@@ -14,6 +14,8 @@ open Frenetic_base.Packet
 module HeadersValues : sig
   type t =
     { location : location
+    ; from : abstract_location
+    ; abstractLoc : abstract_location
     ; ethSrc : dlAddr
     ; ethDst : dlAddr
     ; vlan : int16

--- a/lib/netkat/Syntax.ml
+++ b/lib/netkat/Syntax.ml
@@ -12,6 +12,7 @@ type vswitchId = int64 [@@deriving sexp, compare, eq]
 type vportId = int64 [@@deriving sexp, compare, eq]
 type vfabricId = int64 [@@deriving sexp, compare, eq]
 type metaId = string [@@deriving sexp, compare, eq]
+type abstract_location = string [@@deriving sexp, compare, eq]
 
 let string_of_fastfail = Frenetic_base.OpenFlow.format_list ~to_string:Int32.to_string
 
@@ -39,6 +40,8 @@ type header_val =
   | VPort of vportId
   | VFabric of vfabricId
   | Meta of metaId * int64
+  | From of abstract_location
+  | AbstractLoc of abstract_location
   [@@deriving sexp]
 
 type pred =

--- a/lib/netkat/Syntax.mli
+++ b/lib/netkat/Syntax.mli
@@ -23,6 +23,7 @@ type vswitchId = int64 [@@deriving sexp, compare, eq]
 type vportId = int64 [@@deriving sexp, compare, eq]
 type vfabricId = int64 [@@deriving sexp, compare, eq]
 type metaId = string [@@deriving sexp, compare, eq]
+type abstract_location = string [@@deriving sexp, compare, eq]
 
 (** {2 Policies} *)
 
@@ -52,6 +53,8 @@ type header_val =
   | VPort of vportId
   | VFabric of vfabricId
   | Meta of metaId * int64
+  | From of abstract_location
+  | AbstractLoc of abstract_location
   [@@deriving sexp]
 
 type pred =

--- a/lib/netkat/jbuild
+++ b/lib/netkat/jbuild
@@ -4,11 +4,15 @@
 (rule
  ((targets (Generated_Parser.mly))
   (deps    (Parser.cppo.mly))
-  (action  (run ${bin:cppo} ${<} -U MAKE_PPX -n -o ${@}))))
+  (action  (run ${bin:cppo} ${<} -U MAKE_PPX -U PORTLESS -n -o ${@}))))
+(rule
+ ((targets (Portless_Generated_Parser.mly))
+  (deps    (Parser.cppo.mly))
+  (action  (run ${bin:cppo} ${<} -U MAKE_PPX -D PORTLESS -n -o ${@}))))
 (rule
  ((targets (Tokens.mly))
   (deps    (Parser.cppo.mly))
-  (action  (run ${bin:cppo} ${<} -D MAKE_PPX -n -o ${@}))))
+  (action  (run ${bin:cppo} ${<} -D MAKE_PPX -D PORTLESS -n -o ${@}))))
 
 ;; generate menhir tokens
 (rule
@@ -34,6 +38,9 @@
 (menhir
  ((flags (--external-tokens Lexer))
   (modules (Generated_Parser))))
+(menhir
+ ((flags (--external-tokens Lexer))
+  (modules (Portless_Generated_Parser))))
 
 (library
  ((name        frenetic_netkat)


### PR DESCRIPTION
## Portless NetKAT

Portless NetKAT is a modified version of the NetKAT language for defining policies without ports. The language, takes the regular NetKAT and replaces the `Switch` and `Port` header with `Location` and `From` headers. Here, both `Location` and `From` can take values that either represent a host or a switch. 

#### Simple example policy

Topology:
```
[h1]----1[s1]2---2[s2]1----[h2]
```
Portful Policy:
```
if sw = 1 then
       if pt = 1 then pt := 2
  else if pt = 2 then pt := 1
  else drop
else if sw = 2 then
       if pt = 1 then pt := 2
  else if pt = 2 then pt := 1
  else drop
else drop
```
Equivalent Portless Policy:
```
if loc = "s1" then
       if from = "h1" then loc := "s2"
  else if from = "s2" then loc := "h1"
  else drop
if loc = "s2" then
       if from = "h2" then loc := "s1"
  else if from = "s1" then loc := "h2"
  else drop
else drop
```
### Compilation
As the tables that are finally generated need to talk about ports, the `Frenetic.Netkat.Portless_Compiler` provides a `compile` function with the following signature:

- `val compile: portless_policy -> topo -> portful_policy`

where, 

- `portless_policy` = `Frenetic.Netkat.Syntax.policy`
- `topo` = `Frenetic.Network.Net.Topology.t` (not to be confused with `Frenetic.Net.Topology.t`)
- `portful_policy` = `Frenetic.Netkat.Syntax.policy`

> The topology can be parsed from `dot` or `gml` files using the module `Frenetic.Network.Net.Parse` 
> **NOTE:** The labels for devices are used as the switch and host names.

---
### The `Frenetic.Topology.Mininet` Module

This module defnes the type `topo_name` as follows:
```
type topo_name =
  | Tree of int * int
  | Linear of int
  | Single of int
  | Minimal
```
It also defines the function `topo_from_name` as follows:
```
val topo_from_name: topo_name -> Frenetic.Network.Net.Topology.t
```
This function takes in a `topo_name` and returns the topology representing that name. The generated topology is equivalent to the one that is generated by mininet:
```
$ mn --topo=<topo_name> --mac
```
---

### Start Controller Command

The frenetic `portless-controller` command starts a simple controller that installs the local portless policy to the switches on the netowrk. It has the following flags:
 - `[--policy-file file]` containing NetKAT policy to apply to the network. Defaults to `policy.kat`.
 - `[--topology-file file]` containing .dot topology of network. Defaults to `topology.kat`.
 - `[--topology-name name]` The name of the topology. Same as mn --topo value. Overrides the `--topology-file` value if provided.
 - `[--openflow-port int]` Port to listen on for OpenFlow switches. Defaults to `6633`.

#### Sample Policies for Fully Connected Networks

```bash
$ sudo mn --controller=remote --topo=<topo-name> --mac --arp
$ frenetic portless-controller --topology-name <topo-name> --pol <pol-file>
```
##### topo-name = `minimal`
Portless Policy:
```
if from = "h1" then loc := "h2"
               else loc := "h1"
```
##### topo-name = `single,4`
Portless Policy:
```
     if ethDst = 00:00:00:00:00:01 then loc := "h1"
else if ethDst = 00:00:00:00:00:02 then loc := "h2"
else if ethDst = 00:00:00:00:00:03 then loc := "h3"
else if ethDst = 00:00:00:00:00:04 then loc := "h4"
else drop
```
##### topo-name = `linear,3`
Portless Policy:
```
if ethDst = 00:00:00:00:00:01 then
         if loc = "s1" then loc := "h1"
    else if loc = "s2" then loc := "s1"
    else if loc = "s3" then loc := "s2"
    else drop
else if ethDst = 00:00:00:00:00:02 then
         if loc = "s2" then loc := "h2"
    else if loc = "s1" then loc := "s2"
    else if loc = "s3" then loc := "s2"
    else drop
else if ethDst = 00:00:00:00:00:03 then
         if loc = "s3" then loc := "h3"
    else if loc = "s2" then loc := "s3"
    else if loc = "s1" then loc := "s2"
    else drop
else drop
```
##### topo-name = `tree,2,2`
Portless Policy:
```
if loc = "s1" then
         if from = "s2" then loc := "s3"
    else if from = "s3" then loc := "s2"
    else drop
else if loc = "s2" then
         if ethDst = 00:00:00:00:00:01 then loc := "h1"
    else if ethDst = 00:00:00:00:00:02 then loc := "h2"
    else loc := "s1"
else if loc = "s3" then
         if ethDst = 00:00:00:00:00:03 then loc := "h3"
    else if ethDst = 00:00:00:00:00:04 then loc := "h4"
    else loc := "s1"
else
```
