### PR TITLE
fix #590: more robust way to invoke ppx_sedlex (not supported by jbuilder)

### DIFF
--- a/lib/netkat/jbuild
+++ b/lib/netkat/jbuild
@@ -32,7 +32,7 @@
 (rule
  ((targets (Lexer.ml))
   (deps    (Lexer.sedlex.ml))
-  (action  (run ${ocaml_where}/../sedlex/ppx_sedlex ${<} -o ${@}))))
+  (action  (run ${lib:sedlex:ppx_sedlex} ${<} -o ${@}))))
 
 ;; generate parser
 (menhir


### PR DESCRIPTION
Find `ppx_sedlex` binary more reliably.