### PR TITLE
Avoid illegal _= bindings in Parser.cppo.mly.

### DIFF
--- a/src/lib/netkat/Parser.cppo.mly
+++ b/src/lib/netkat/Parser.cppo.mly
@@ -207,7 +207,7 @@ header_val(BINOP):
 #ifdef PORTLESS
   | SWITCH; BINOP; n=int64
       BOTH( raise (Failure "cannot access switch field in portless mode") )
-  | PORT; BINOP; _=portval
+  | PORT; BINOP; portval
       BOTH( raise (Failure "cannot access port field in portless mode") )
   | FROM; BINOP; s=STRING
       BOTH( From s )
@@ -220,9 +220,9 @@ header_val(BINOP):
   | PORT; BINOP; p=portval
       AST( Location p )
       PPX( Location [%e p] )
-  | FROM; BINOP; _=STRING
+  | FROM; BINOP; STRING
       BOTH( raise (Failure "from field only available in portless mode") )
-  | ABSTRACTLOC; BINOP; _=STRING
+  | ABSTRACTLOC; BINOP; STRING
       BOTH( raise (Failure "loc field only available in portless mode") )
 #endif
   | VSWITCH; BINOP; n=int64


### PR DESCRIPTION
Hello,

Using a wildcard pattern "_" in a place where a variable name is expected has never been legal, even though (by luck) it was accepted until now by Menhir. It will likely be disallowed in the next release, so I suggest avoiding these illegal bindings.

The existing opam package descriptions for frenetic should also be updated to require Menhir <= 20181026.

Cheers,
François.