### PR TITLE
Note that Menhir is only a build dependency.

### DIFF
--- a/frenetic.opam
+++ b/frenetic.opam
@@ -25,7 +25,7 @@ depends: [
   "cstruct" {>= "1.0.1"}
   "cstruct-async"
   "ipaddr" {>= "2.5.0"}
-  "menhir"
+  "menhir" {build}
   "mparser"
   "ocamlgraph" {>= "1.8.7"}
   "open"


### PR DESCRIPTION
This should remove the need to recompile frenetic when Menhir is updated.
Since frenetic doesn't use Menhir's `--table` mode,  it doesn't depend on MenhirLib, so this should be OK.