### PR TITLE
Pin cstruct to < 4.0.0

### DIFF
--- a/frenetic.opam
+++ b/frenetic.opam
@@ -24,7 +24,7 @@ depends: [
   "cohttp"
   "cohttp-async"
   "core"   {>= "v0.11.0" & < "v0.12.0"}
-  "cstruct" {>= "1.0.1"}
+  "cstruct" {>= "1.0.1" & < "4.0.0"}
   "cstruct-async"
   "ipaddr" {>= "2.5.0"}
   "menhir"


### PR DESCRIPTION
Cstruct 4.0 makes some breaking changes; in particular, it factors out s-expression support into a separate library. 
This addresses #633