### PR TITLE
New Domain and Packet modules; fixes

### DIFF
--- a/frenetic.opam
+++ b/frenetic.opam
@@ -24,7 +24,8 @@ depends: [
   "cohttp"
   "cohttp-async"
   "core"   {>= "v0.11.0" & < "v0.12.0"}
-  "cstruct" {>= "1.0.1" & < "4.0.0"}
+  "cstruct" {>= "1.0.1"}
+  "cstruct-sexp"
   "cstruct-async"
   "ipaddr" {>= "2.5.0"}
   "menhir"
@@ -38,5 +39,5 @@ depends: [
   "sedlex" {>= "2.0"}
   "sexplib"
   "tcpip"
-  "yojson" {>= "1.2.0"}
+  "yojson" {>= "1.7.0"}
 ]

--- a/src/lib/kernel/OpenFlow.ml
+++ b/src/lib/kernel/OpenFlow.ml
@@ -272,11 +272,11 @@ type flow = {
 type flowTable = flow list [@@deriving sexp]
 
 type payload =
-  | Buffered of bufferId * Cstruct.t
-  | NotBuffered of Cstruct.t
+  | Buffered of bufferId * Cstruct_sexp.t
+  | NotBuffered of Cstruct_sexp.t
 [@@deriving sexp]
 
-let payload_bytes (payload : payload) : Cstruct.t =
+let payload_bytes (payload : payload) : Cstruct_sexp.t =
   match payload with
   | Buffered(_, b)
   | NotBuffered(b) -> b

--- a/src/lib/kernel/OpenFlow0x01.ml
+++ b/src/lib/kernel/OpenFlow0x01.ml
@@ -83,8 +83,8 @@ type flowMod =
     } [@@deriving sexp]
 
 type payload =
-  | Buffered of int32 * Cstruct.t
-  | NotBuffered of Cstruct.t
+  | Buffered of int32 * Cstruct_sexp.t
+  | NotBuffered of Cstruct_sexp.t
 [@@deriving sexp]
 
 type packetInReason =
@@ -2766,7 +2766,7 @@ module Error = struct
   [@@deriving sexp]
 
   type t =
-    | Error of c * Cstruct.t sexp_opaque
+    | Error of c * Cstruct_sexp.t sexp_opaque
   [@@deriving sexp]
 
   let parse bits =
@@ -2840,7 +2840,7 @@ end
 
 module Vendor = struct
 
-  type t = int32 * Cstruct.t sexp_opaque
+  type t = int32 * Cstruct_sexp.t sexp_opaque
   [@@deriving sexp]
 
   [%%cstruct
@@ -2924,10 +2924,10 @@ module Message = struct
     | QUEUE_GET_CONFIG_RESP -> "QUEUE_GET_CONFIG_RESP"
 
   type t =
-    | Hello of Cstruct.t
+    | Hello of Cstruct_sexp.t
     | ErrorMsg of Error.t
-    | EchoRequest of Cstruct.t
-    | EchoReply of Cstruct.t
+    | EchoRequest of Cstruct_sexp.t
+    | EchoReply of Cstruct_sexp.t
     | VendorMsg of Vendor.t
     | SwitchFeaturesRequest
     | SwitchFeaturesReply of SwitchFeatures.t
@@ -3044,7 +3044,7 @@ module Message = struct
     | StatsReplyMsg msg -> StatsReply.size_of msg
     (**| code -> raise (Invalid_argument (Printf.sprintf "cannot marshal (controller should not send message this message (%s) to a switch)" (to_string msg)))*)
 
-  let blit_message (msg : t) (out : Cstruct.t) = match msg with
+  let blit_message (msg : t) (out : Cstruct_sexp.t) = match msg with
     | Hello buf
     | EchoRequest buf
     | EchoReply buf ->

--- a/src/lib/kernel/Packet.ml
+++ b/src/lib/kernel/Packet.ml
@@ -74,7 +74,7 @@ let sexp_of_bytes s =
   done;
   Sexp.Atom (Buffer.contents buf)
 
-type bytes = Cstruct.t
+type bytes = Cstruct_sexp.t
 
 type int8 = int [@@deriving sexp, compare]
 
@@ -158,7 +158,7 @@ module Tcp = struct
     ; window : int16
     ; chksum : int16
     ; urgent : int16
-    ; payload : Cstruct.t } [@@deriving sexp]
+    ; payload : Cstruct_sexp.t } [@@deriving sexp]
 
   let format fmt v =
     let open Format in
@@ -243,7 +243,7 @@ module Udp = struct
     { src : tpPort
     ; dst : tpPort
     ; chksum : int16
-    ; payload : Cstruct.t }
+    ; payload : Cstruct_sexp.t }
   [@@deriving sexp]
 
   let format fmt v =
@@ -289,7 +289,7 @@ module Icmp = struct
     typ : int8;
     code : int8;
     chksum : int16;
-    payload : Cstruct.t
+    payload : Cstruct_sexp.t
   } [@@deriving sexp]
 
   [%%cstruct
@@ -416,7 +416,7 @@ module Dns = struct
       typ : int16;
       class_ : int16;
       ttl : int; (* TTL is signed 32-bit int *)
-      rdata : Cstruct.t
+      rdata : Cstruct_sexp.t
     } [@@deriving sexp]
 
     [%%cstruct
@@ -694,7 +694,7 @@ module Igmp = struct
   type msg =
     | Igmp1and2 of Igmp1and2.t
     | Igmp3 of Igmp3.t
-    | Unparsable of (int8 * Cstruct.t)
+    | Unparsable of (int8 * Cstruct_sexp.t)
   [@@deriving sexp]
 
   type t = {
@@ -781,7 +781,7 @@ module Ip = struct
     | Udp of Udp.t
     | Icmp of Icmp.t
     | Igmp of Igmp.t
-    | Unparsable of (nwProto * Cstruct.t)
+    | Unparsable of (nwProto * Cstruct_sexp.t)
   [@@deriving sexp]
 
   module Flags = struct
@@ -815,7 +815,7 @@ module Ip = struct
     chksum : int16;
     src : nwAddr;
     dst : nwAddr;
-    options : Cstruct.t;
+    options : Cstruct_sexp.t;
     tp : tp
   } [@@deriving sexp]
 
@@ -1042,7 +1042,7 @@ end
 type nw =
   | Ip of Ip.t
   | Arp of Arp.t
-  | Unparsable of (dlTyp * Cstruct.t)
+  | Unparsable of (dlTyp * Cstruct_sexp.t)
   [@@deriving sexp]
 
 type packet = {

--- a/src/lib/kernel/dune
+++ b/src/lib/kernel/dune
@@ -2,7 +2,7 @@
  (name frenetic_kernel)
  (public_name frenetic.kernel)
  (wrapped true)
- (libraries core base64 cstruct ocamlgraph open tcpip yojson ipaddr sedlex
+ (libraries core base64 cstruct cstruct-sexp ocamlgraph open tcpip yojson ipaddr sedlex
    sexplib str menhirLib compiler-libs.common)
  (preprocess
   (pps ppx_cstruct ppx_deriving.std ppx_jane))

--- a/src/lib/netkat/Domain.ml
+++ b/src/lib/netkat/Domain.ml
@@ -1,79 +1,63 @@
-(** The domain of an FDD/Automaton *)
-
 open Core
 
 module FDD = Fdd.FDD
 
-module Field = struct
-  module T = struct
-    include Fdd.Field
-    let compare (x : t) (y : t) = Int.compare (Obj.magic x) (Obj.magic y)
-  end
-  include T
-  include Comparator.Make(T)
-end
+module Field = Packet.Field
 
 type t = Set.M(Int64).t Map.M(Field).t
+
+let empty : t = Map.empty (module Field) 
 
 let merge : t -> t -> t =
   Map.merge_skewed ~combine:(fun ~key -> Set.union)
 
-let of_fdd (fdd : FDD.t) : t =
-  let rec for_fdd dom fdd =
-    match FDD.unget fdd with
-    | Leaf r ->
-      for_leaf dom r
-    | Branch {test=(field,_)} ->
-      let vs, residuals =
-        for_field field fdd (Set.empty (module Int64)) (Set.empty (module FDD))
-      in
-      let dom = Map.update dom field ~f:(function
-        | None -> vs
-        | Some vs' -> Set.union vs vs')
-      in
-      Set.fold residuals ~init:dom ~f:for_fdd
+let rec of_fdd (fdd : FDD.t) : t =
+  for_fdd empty fdd
 
-  (** returns list of values appearing in tests with field [f] in [fdd], and
-      residual trees below f-tests. *)
-  and for_field f fdd vs residuals =
-    match FDD.unget fdd with
-    | Branch {test=(f',v); tru; fls} when f' = f ->
-      let vs = match v with Const v -> Set.add vs v | _ -> vs in
-      for_field f fls vs (Set.add residuals tru)
-    | Branch _ | Leaf _ ->
-      (vs, Set.add residuals fdd)
+and for_fdd dom fdd =
+  match FDD.unget fdd with
+  | Leaf r ->
+    for_leaf dom r
+  | Branch {test=(field,_)} ->
+    let vs, residuals =
+      for_field field fdd (Set.empty (module Int64)) (Set.empty (module FDD))
+    in
+    let dom = Map.update dom field ~f:(function
+      | None -> vs
+      | Some vs' -> Set.union vs vs')
+    in
+    Set.fold residuals ~init:dom ~f:for_fdd
 
-  and for_leaf dom act =
-    Set.fold act ~init:dom ~f:for_seq
+(** returns list of values appearing in tests with field [f] in [fdd], and
+    residual trees below f-tests. *)
+and for_field f fdd vs residuals =
+  match FDD.unget fdd with
+  | Branch {test=(f',v); tru; fls} when f' = f ->
+    let vs = match v with Const v -> Set.add vs v | _ -> vs in
+    for_field f fls vs (Set.add residuals tru)
+  | Branch _ | Leaf _ ->
+    (vs, Set.add residuals fdd)
 
-  and for_seq dom seq =
-    Map.to_alist seq
-    |> List.fold ~init:dom ~f:(fun dom -> function
-      | (F f, Const v) ->
-        Map.update dom f ~f:(function
-          | None -> Set.singleton (module Int64) v
-          | Some vs -> Set.add vs v
-        )
-      | _ ->
-        dom
-    )
+and for_leaf dom act =
+  Set.fold act ~init:dom ~f:for_seq
 
-
-  in
-  for_fdd (Map.empty (module Field)) fdd
-
-
-
-(*
-let pre_variants (dom : t) : PrePacket.t list =
-  Map.fold dom ~init:[PrePacket.empty] ~f:(fun ~key:f ~data:vs pks ->
-    Valset.to_list vs
-    |> List.concat_map ~f:(fun v -> List.map pks ~f:(fun pk ->
-      PrePacket.modify pk f v))
+and for_seq dom seq =
+  Map.to_alist seq
+  |> List.fold ~init:dom ~f:(fun dom -> function
+    | (F f, Const v) ->
+      Map.update dom f ~f:(function
+        | None -> Set.singleton (module Int64) v
+        | Some vs -> Set.add vs v
+      )
+    | _ ->
+      dom
   )
 
-let variants (dom : t) : Packet.t list =
-  pre_variants dom
-  |> List.map ~f:(fun pk -> Packet.Pk pk)
-  |> List.cons (Packet.Emptyset)
- *)
+
+module Auto = Global_compiler.Automaton
+
+let of_automaton (auto : Auto.t) : t =
+  Auto.fold_reachable auto ~init:empty ~f:(fun dom _ (e,d) ->
+    for_fdd (for_fdd dom e) d
+  )
+

--- a/src/lib/netkat/Domain.ml
+++ b/src/lib/netkat/Domain.ml
@@ -1,0 +1,83 @@
+(** The domain of an FDD/Automaton *)
+
+open Core
+
+module FDD = Fdd.FDD
+
+module Field = struct
+  module T = struct
+    include Fdd.Field
+    let compare x y = Int.compare (Obj.magic x) (Obj.magic y)
+  end
+  include T
+  include Comparator.Make(T)
+end
+
+type t = Set.M(Int64).t Map.M(Field).t
+
+
+let merge : t -> t -> t =
+  Map.merge_skewed ~combine:(fun ~key -> Set.union)
+
+
+let of_fdd (fdd : FDD.t) : t =
+  let rec for_fdd dom fdd =
+    match FDD.unget fdd with
+    | Leaf r ->
+      for_leaf dom r
+    | Branch {test=(field,_)} ->
+      let (vs, residuals, all_false) =
+        for_field field fdd (Set.empty (module Int64)) []
+      in
+      let dom = Map.update dom field ~f:(function
+        | None -> vs
+        | Some vs' -> Set.union vs vs')
+      in
+      List.fold residuals ~init:dom ~f:for_fdd
+
+
+  (** returns list of values appearing in tests with field [f] in [fdd], and
+      residual trees below f-tests, and the all-false branch with respect to
+      field f. *)
+  and for_field f fdd vs residual =
+    match FDD.unget fdd with
+    | Branch {test=(f',v); tru; fls} when f' = f ->
+      let vs = match v with Const v -> Set.add vs v | _ -> vs in
+      for_field f fls vs (tru::residual)
+    | Branch _ | Leaf _ ->
+      (vs, fdd::residual, fdd)
+
+  and for_leaf dom act =
+    Set.fold act ~init:dom ~f:for_seq
+
+  and for_seq dom seq =
+    Map.to_alist seq
+    |> List.fold ~init:dom ~f:(fun dom -> function
+      | (F f, Const v) ->
+        Map.update dom f ~f:(function
+          | None -> Set.singleton (module Int64) v
+          | Some vs -> Set.add vs v
+        )
+      | _ ->
+        dom
+    )
+
+
+  in
+  for_fdd (Map.empty (module Field)) fdd
+
+
+
+(*
+let pre_variants (dom : t) : PrePacket.t list =
+  Map.fold dom ~init:[PrePacket.empty] ~f:(fun ~key:f ~data:vs pks ->
+    Valset.to_list vs
+    |> List.concat_map ~f:(fun v -> List.map pks ~f:(fun pk ->
+      PrePacket.modify pk f v))
+  )
+
+let variants (dom : t) : Packet.t list =
+  pre_variants dom
+  |> List.map ~f:(fun pk -> Packet.Pk pk)
+  |> List.cons (Packet.Emptyset)
+ *)

--- a/src/lib/netkat/Domain.ml
+++ b/src/lib/netkat/Domain.ml
@@ -61,3 +61,13 @@ let of_automaton (auto : Auto.t) : t =
     for_fdd (for_fdd dom e) d
   )
 
+
+let representative_pks (t : t) : Packet.t list =
+  Map.fold t ~init:[Packet.empty] ~f:(fun ~key:field ~data:vs pks ->
+    Set.to_list vs
+    (* add fresh value, representing the case that all tests fails *)
+    |> List.cons Int64.(Set.min_elt_exn vs - 1L)
+    |> List.concat_map ~f:(fun v ->
+      List.map pks ~f:(Map.add_exn ~key:field ~data:v)
+    )
+  )

--- a/src/lib/netkat/Domain.mli
+++ b/src/lib/netkat/Domain.mli
@@ -1,0 +1,20 @@
+(** The domain of an FDD/Automaton is given by the set of values occuring with
+    each field, either in a test or a modification.
+ *)
+
+open Core
+
+module Field : sig
+  type t = Fdd.Field.t [@@deriving compare]
+  include Comparator.S with type t := t
+end
+
+type t = Set.M(Int64).t Map.M(Field).t  (** for each field, a set of values *)
+
+val empty : t
+
+val merge : t -> t -> t
+
+val of_fdd : Fdd.FDD.t -> t
+
+val of_automaton : Global_compiler.Automaton.t -> t

--- a/src/lib/netkat/Domain.mli
+++ b/src/lib/netkat/Domain.mli
@@ -18,3 +18,5 @@ val merge : t -> t -> t
 val of_fdd : Fdd.FDD.t -> t
 
 val of_automaton : Global_compiler.Automaton.t -> t
+
+val representative_pks : t -> Packet.t list

--- a/src/lib/netkat/Global_compiler.mli
+++ b/src/lib/netkat/Global_compiler.mli
@@ -5,7 +5,11 @@ module FDD : module type of Local_compiler.FDD
 
 (** Intermediate representation of global compiler: NetKAT Automata *)
 module Automaton : sig
-  type t
+  type t = private
+    { states : (int64, FDD.t * FDD.t) Hashtbl.t;
+      has_state : (FDD.t * FDD.t, int64) Hashtbl.t;
+      mutable source : int64;
+      mutable nextState : int64 }
 
   val fold_reachable: ?order:[< `Post | `Pre > `Pre ]
     -> t

--- a/src/lib/netkat/Packet.ml
+++ b/src/lib/netkat/Packet.ml
@@ -1,0 +1,34 @@
+open Core
+
+module Field = struct
+  module T = struct
+    include Fdd.Field
+    let compare (x : t) (y : t) = Int.compare (Obj.magic x) (Obj.magic y)
+  end
+  include T
+  include Comparator.Make(T)
+end
+
+module T0 = struct
+  type t = int64 Base.Map.M(Field).t
+    [@@deriving compare, sexp, hash]
+end
+
+module T = struct
+  include T0
+  include Comparator.Make(T0)
+end
+
+include T
+
+let apply_action_seq (pk : t) (seq : Fdd.Value.t Fdd.Action.Seq.t) : t =
+  Map.to_alist seq
+  |> List.fold ~init:pk ~f:(fun pk -> function 
+    | F f, Const v -> Map.set pk ~key:f ~data:v
+    | F _, _ -> failwith "unexpected action"
+    | K, _ -> pk
+  )
+
+let apply_action (pk : t) (act : Fdd.Action.t) : Set.M(T).t =
+  Set.map (module T) act ~f:(apply_action_seq pk) 
+

--- a/src/lib/netkat/Packet.mli
+++ b/src/lib/netkat/Packet.mli
@@ -15,5 +15,6 @@ end
 
 include T
 
-val apply_action_seq : t -> Fdd.Value.t Fdd.Action.Seq.t -> t
+val apply_fdd : t -> Fdd.FDD.t -> Fdd.Action.t
 val apply_action : t -> Fdd.Action.t -> Set.M(T).t
+val apply_action_seq : t -> Fdd.Value.t Fdd.Action.Seq.t -> t

--- a/src/lib/netkat/Packet.mli
+++ b/src/lib/netkat/Packet.mli
@@ -1,0 +1,19 @@
+(** A packet is a map from fields to values. *)
+
+open Core
+
+module Field : sig
+  type t = Fdd.Field.t [@@deriving compare]
+  include Comparator.S with type t := t
+end
+
+module T : sig
+  type t = int64 Map.M(Field).t
+    [@@deriving sexp, compare, hash]
+  include Comparator.S with type t := t
+end
+
+include T
+
+val apply_action_seq : t -> Fdd.Value.t Fdd.Action.Seq.t -> t
+val apply_action : t -> Fdd.Action.t -> Set.M(T).t

--- a/src/lib/netkat/Packet.mli
+++ b/src/lib/netkat/Packet.mli
@@ -13,8 +13,14 @@ module T : sig
   include Comparator.S with type t := t
 end
 
-include T
+include T with type t = int64 Map.M(Field).t
 
-val apply_fdd : t -> Fdd.FDD.t -> Fdd.Action.t
-val apply_action : t -> Fdd.Action.t -> Set.M(T).t
-val apply_action_seq : t -> Fdd.Value.t Fdd.Action.Seq.t -> t
+(** the packet with no fields *)
+val empty : t
+
+val apply_fdd : Fdd.FDD.t -> t -> Fdd.Action.t
+val apply_action : Fdd.Action.t -> t -> Set.M(T).t
+val apply_action_seq : Fdd.Value.t Fdd.Action.Seq.t -> t -> t
+
+val eval_e_fdd : Fdd.FDD.t -> t -> Set.M(T).t
+val eval_d_fdd : Fdd.FDD.t -> t -> int64 Map.M(T).t

--- a/src/lib/netkat/Vlr.mli
+++ b/src/lib/netkat/Vlr.mli
@@ -76,6 +76,8 @@ module Make(V:HashCmp)(L:Lattice)(R:Result) : sig
   (** A decision diagram index.  All diagrams and subdiagrams within it are given an
   index.  You can convert this to a tree with [unget], and from a tree with [get]. *)
 
+  include Comparator.S with type t := t
+
   type v = V.t * L.t
   (** The type of a variable in the decision diagram. *)
 


### PR DESCRIPTION
Fixed some dependencies:
* upgrade to cstruct 4.0.0
* upgrade to yojson 1.7.0

Improved some interfaces:
* Global compiler now exposes automaton type, safely (using `private`)
* Use `Hashtbl.foo` instead of specialized `Tbl.foo` in various places.

Added two new modules:
* Packet.ml: Models packets as maps from fields to integers.
* Domain.ml: The domain of a FDD/Automaton/... is the set of fields that appear in it, together with the set of values that appear with each field (in a test or a modification).