### PR TITLE
Port Frenetic to OCaml 4.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ env:
   - PACKAGE=frenetic
   - secure: S2gNgyfUoFT0UZp0AFh34Rh6teIQ2dC8qjrsN+Lr7IWsjglre0HnSfzpFwpCES810LcZanHT3V7BKwbOUse/1pjqW2bXYPqbbdplwaY+PK6gkc9JDEOgXOyoPHbtmBAT2n20OAvz7Ih0CUMlLwBJyBlpi6LA+Zk2uYUhjUY32us=
   matrix:
-  - OCAML=4.06.1
-  - OCAML=4.07.1
+  - OCAML=4.11.0
 script:
 - echo "yes" | sudo add-apt-repository ppa:avsm/ppa
 - sudo apt-get update -qq

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 1.9)
+(lang dune 2.0)
 (name frenetic)
 (using menhir 2.0)
 (allow_approximate_merlin)

--- a/frenetic.opam
+++ b/frenetic.opam
@@ -19,7 +19,6 @@ depends: [
   "odoc"
   #########################
   "async"  {>= "v0.14.0" }
-  "async_extended" {>= "v0.14.0" }
   "base64" {>= "3.4.0"}
   "cohttp" {>= "2.5.4"}
   "cohttp-async" {>= "2.5.4" }

--- a/frenetic.opam
+++ b/frenetic.opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-version: "5.0.3"
+version: "5.0.4"
 synopsis: "The Frenetic Programming Language and Runtime System"
 maintainer: "Steffen Smolka <smolka@cs.cornell.edu>"
 authors: "Arjun Guha <arjun@cs.umass.edu>, Nate Foster <jnfoster@cs.cornell.edu>, Steffen Smolka <smolka@cs.cornell.edu>"
@@ -13,31 +13,30 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "ocaml" {build & >= "4.05.0"}
-  "cppo"
-  "dune" {build & >= "1.0"}
+  "ocaml" {build & >= "4.11.0"}
+  "cppo" {>= "1.6.6" }
+  "dune" {build & >= "2.0"}
   "odoc"
   #########################
-  "async"  {>= "v0.11.0" & < "v0.12.0"}
-  "async_extended" {>= "v0.11.0" & < "v0.12.0"}
-  "base64" {>= "3.0.0"}
-  "cohttp"
-  "cohttp-async"
-  "core"   {>= "v0.11.0" & < "v0.12.0"}
-  "cstruct" {>= "1.0.1"}
-  "cstruct-sexp"
-  "cstruct-async"
-  "ipaddr" {>= "2.5.0"}
-  "menhir"
-  "mparser"
-  "ocamlgraph" {>= "1.8.7"}
-  "open"
-  "ppxlib"
-  "ppx_jane"
-  "ppx_cstruct"
-  "ppx_deriving" {>= "4.2"}
-  "sedlex" {>= "2.0"}
-  "sexplib"
-  "tcpip"
+  "async"  {>= "v0.14.0" }
+  "async_extended" {>= "v0.14.0" }
+  "base64" {>= "3.4.0"}
+  "cohttp" {>= "2.5.4"}
+  "cohttp-async" {>= "2.5.4" }
+  "core"   {>= "v0.14.0" }
+  "cstruct" {>= "5.2.0"}
+  "cstruct-sexp" {>= "5.2.0"}
+  "ipaddr" {>= "5.0.1"}
+  "menhir" {>= "20200624"}
+  "mparser" {>= "1.2.3"}
+  "ocamlgraph" {>= "2.0.0"}
+  "open" {>= "0.2.1"}
+  "ppxlib" {>= "0.15.0"}
+  "ppx_jane" {>= "0.14.0"}
+  "ppx_cstruct" {>= "5.2.0"}
+  "ppx_deriving" {>= "5.1"}
+  "sedlex" {>= "2.2"}
+  "sexplib" {>= "0.14.0"}
+  "tcpip" {>= "5.0.1"}
   "yojson" {>= "1.7.0"}
 ]

--- a/src/exe/Dump.ml
+++ b/src/exe/Dump.ml
@@ -134,48 +134,48 @@ module Flag = struct
       ~doc: " Print FDD field order used by the compiler."
 
   let vpol =
-    flag "--vpol" (optional_with_default "vpol.dot" file)
+    flag "--vpol" (optional_with_default "vpol.dot" string)
       ~doc: "file Virtual policy. Must not contain links. \
              If not specified, defaults to vpol.dot"
 
   let vrel =
-    flag "--vrel" (optional_with_default "vrel.kat" file)
+    flag "--vrel" (optional_with_default "vrel.kat" string)
       ~doc: "file Virtual-physical relation. If not specified, defaults to vrel.kat"
 
   let vtopo =
-    flag "--vtopo" (optional_with_default "vtopo.kat" file)
+    flag "--vtopo" (optional_with_default "vtopo.kat" string)
       ~doc: "file Virtual topology. If not specified, defaults to vtopo.kat"
 
   let ving_pol =
-    flag "--ving-pol" (optional_with_default "ving_pol.kat" file)
+    flag "--ving-pol" (optional_with_default "ving_pol.kat" string)
       ~doc: "file Virtual ingress policy. If not specified, defaults to ving_pol.kat"
 
   let ving =
-    flag "--ving" (optional_with_default "ving.kat" file)
+    flag "--ving" (optional_with_default "ving.kat" string)
       ~doc: "file Virtual ingress predicate. If not specified, defaults to ving.kat"
 
   let veg =
-    flag "--veg" (optional_with_default "veg.kat" file)
+    flag "--veg" (optional_with_default "veg.kat" string)
       ~doc: "file Virtual egress predicate. If not specified, defaults to veg.kat"
 
   let ptopo =
-    flag "--ptopo" (optional_with_default "ptopo.kat" file)
+    flag "--ptopo" (optional_with_default "ptopo.kat" string)
       ~doc: "file Physical topology. If not specified, defaults to ptopo.kat"
 
   let ping =
-    flag "--ping" (optional_with_default "ping.kat" file)
+    flag "--ping" (optional_with_default "ping.kat" string)
       ~doc: "file Physical ingress predicate. If not specified, defaults to ping.kat"
 
   let peg =
-    flag "--peg" (optional_with_default "peg.kat" file)
+    flag "--peg" (optional_with_default "peg.kat" string)
       ~doc: "file Physical egress predicate. If not specified, defaults to peg.kat"
 
   let dump_local =
-    flag "--dump-local" (optional file)
+    flag "--dump-local" (optional string)
       ~doc: "file Translate compiler output to local program and dump it to file"
 
   let dump_global =
-    flag "--dump-global" (optional file)
+    flag "--dump-global" (optional string)
       ~doc: "file Translate compiler output to global program and dump it to file"
 
   let determinize =
@@ -211,7 +211,7 @@ end
 module Local = struct
   let spec = Command.Spec.(
     empty
-    +> anon ("file" %: file)
+    +> anon ("file" %: string)
     +> Flag.switches
     +> Flag.print_fdd
     +> Flag.dump_fdd
@@ -250,7 +250,7 @@ end
 module Global = struct
   let spec = Command.Spec.(
     empty
-    +> anon ("file" %: file)
+    +> anon ("file" %: string)
     +> Flag.print_fdd
     +> Flag.dump_fdd
     +> Flag.render_fdd
@@ -291,7 +291,7 @@ end
 module Virtual = struct
   let spec = Command.Spec.(
     empty
-    +> anon ("file" %: file)
+    +> anon ("file" %: string)
     +> Flag.vrel
     +> Flag.vtopo
     +> Flag.ving_pol
@@ -362,7 +362,7 @@ end
 module Auto = struct
   let spec = Command.Spec.(
     empty
-    +> anon ("file" %: file)
+    +> anon ("file" %: string)
     +> Flag.json
     +> Flag.print_order
     +> Flag.determinize
@@ -388,8 +388,8 @@ end
 module Bisim = struct
   let spec = Command.Spec.(
       empty
-      +> anon ("file1" %: file)
-      +> anon ("file2" %: file)
+      +> anon ("file1" %: string)
+      +> anon ("file2" %: string)
       +> Flag.json
       +> Flag.stdin
       +> Flag.containment

--- a/src/exe/dune
+++ b/src/exe/dune
@@ -1,5 +1,5 @@
 (executables
  (names main openflow)
  (public_names frenetic frenetic.openflow)
- (libraries core async async_extended frenetic)
+ (libraries core async frenetic)
  (flags :standard -safe-string))

--- a/src/exe/main.ml
+++ b/src/exe/main.ml
@@ -16,13 +16,13 @@ let verbosity_levels : Async.Log.Level.t Command.Spec.Arg_type.t =
         exit 1)
 
 let default_log_device =
-  ("stderr", lazy (Async_extended.Extended_log.Console.output (Lazy.force Async.Writer.stderr)))
+  ("stderr", lazy (Async.Log.Output.writer `Text (Lazy.force Async.Writer.stderr)))
 
 let log_outputs : (string * Async.Log.Output.t Lazy.t) Command.Spec.Arg_type.t =
   Command.Spec.Arg_type.create
     (function
       | "stderr" -> default_log_device
-      | "stdout" -> ("stdout", lazy (Async_extended.Extended_log.Console.output (Lazy.force Async.Writer.stdout)))
+      | "stdout" -> ("stdout", lazy (Async.Log.Output.writer `Text (Lazy.force Async.Writer.stdout)))
       | filename -> (filename, lazy (Async.Log.Output.file `Text filename)) )
 
 let table_fields : Netkat.Local_compiler.flow_layout Command.Spec.Arg_type.t =
@@ -92,11 +92,11 @@ module Flag = struct
       ~doc:"Partition of fields into Openflow 1.3 tables, e.g. ethsrc,ethdst;ipsrc,ipdst"
 
   let policy_file =
-    flag "--policy-file" (optional_with_default "policy.kat" file)
+    flag "--policy-file" (optional_with_default "policy.kat" string)
     ~doc:"File containing NetKAT policy to apply to the network. Defaults to \"policy.kat\"."
 
   let topology_file =
-    flag "--topology-file" (optional_with_default "topology.dot" file)
+    flag "--topology-file" (optional_with_default "topology.dot" string)
       ~doc:"File containing .dot topology of network. Defaults to \"topology.kat\"."
 
   let topology_name =

--- a/src/lib/async/dune
+++ b/src/lib/async/dune
@@ -2,7 +2,7 @@
  (name frenetic_async)
  (public_name frenetic.async)
  (wrapped true)
- (libraries async cohttp cohttp-async core cstruct cstruct-async
+ (libraries async cohttp cohttp-async core cstruct
    frenetic.kernel frenetic.netkat mparser mparser.re str)
  (preprocess
   (pps ppx_sexp_conv))

--- a/src/lib/kernel/GroupTable0x04.ml
+++ b/src/lib/kernel/GroupTable0x04.ml
@@ -39,7 +39,7 @@ let to_string t =
 let next_group_id (tbl : t) =
   let id = tbl.next_group_id in
   tbl.next_group_id <- Int32.succ id;
-  if tbl.next_group_id = 0l then
+  if Poly.(tbl.next_group_id = 0l) then
     failwith "out of group IDs"
   else
     id

--- a/src/lib/kernel/Network.ml
+++ b/src/lib/kernel/Network.ml
@@ -275,7 +275,7 @@ struct
       try
         let es = P.find_all_edges t.graph v1 v2 in
         let es' = List.filter es ( fun (s,l,d) ->
-          l.src = p1 && l.dst = p2 ) in
+          Poly.(l.src = p1 && l.dst = p2) ) in
         match es' with
           | [] -> aux t
           | es ->
@@ -338,7 +338,7 @@ struct
       let dst_vertex, dst_port = edge_dst e in
       try
         let inv_e = find_edge t dst_vertex src_vertex in
-        if dst_port = snd (edge_src inv_e) && src_port = snd (edge_dst inv_e)
+        if Poly.(dst_port = snd (edge_src inv_e) && src_port = snd (edge_dst inv_e))
         then Some(inv_e)
         else None
       with _ -> None
@@ -347,7 +347,7 @@ struct
       let rec loop es = match es with
         | [] -> None
         | ((_,l,v2) as e)::es' ->
-          if l.EL.src = p
+          if Poly.(l.EL.src = p)
             then Some e
             else (loop es') in
       loop (P.succ_e t.graph v1)
@@ -388,7 +388,7 @@ struct
 
     let remove_endpoint (t:t) (ep : vertex * port) : t =
       let t = fold_edges (fun e acc ->
-        if edge_src e = ep || edge_dst e = ep
+        if Poly.(edge_src e = ep || edge_dst e = ep)
           then remove_edge acc e
           else acc)
         t t
@@ -488,7 +488,7 @@ struct
         let rec traverse_parent x ret =
           let e = VertexHash.find_exn admissible x in
           let s,_ = edge_src e in
-          if s = x0 then e :: ret else traverse_parent s (e :: ret) in
+          if Poly.(s = x0) then e :: ret else traverse_parent s (e :: ret) in
         traverse_parent x0 [] in
       let find_cycle x0 =
         let rec visit x visited =
@@ -759,7 +759,7 @@ struct
         let _,dst_port = edge_dst (s,l,d) in
         Printf.sprintf "%s%s%s -> %s {src_port=%lu; dst_port=%lu; %s};"
           acc
-          (if acc = "" then "" else "\n")
+          (if Poly.(acc = "") then "" else "\n")
           (Vertex.to_string s.VL.label)
           (Vertex.to_string d.VL.label)
           src_port
@@ -768,7 +768,7 @@ struct
       let vs = (VertexSet.fold (vertexes t) ~init:"" ~f:(fun acc v ->
         Printf.sprintf "%s%s\n%s;"
           acc
-          (if acc = "" then "" else "\n")
+          (if Poly.(acc = "") then "" else "\n")
           (Vertex.to_dot v.VL.label)
       )) in
       Printf.sprintf "digraph G {\n%s\n%s\n}\n" vs es
@@ -792,7 +792,7 @@ struct
         let inverse = match inverse_edge t e with
           | None -> false
           | Some e -> EdgeSet.mem !seen e in
-        src = dst ||
+        Poly.(src = dst) ||
         EdgeSet.mem !seen e ||
         inverse
       in
@@ -1088,7 +1088,7 @@ module Weight = struct
   let weight l =
     let open Link in
     l.weight
-  let compare = compare
+  let compare = Poly.compare
   let add = (+.)
   let zero = 0.
 end

--- a/src/lib/kernel/OpenFlow.ml
+++ b/src/lib/kernel/OpenFlow.ml
@@ -38,7 +38,7 @@ let format_ip (fmt : Format.formatter) (v:int32) =
 let format_ip_mask (fmt : Format.formatter) ((p,m) : nwAddr * int32) =
   Format.fprintf fmt "%a%s"
     format_ip p
-    (if m = 32l then "" else Printf.sprintf "/%ld" m)
+    (if Poly.(m = 32l) then "" else Printf.sprintf "/%ld" m)
 
 module Pattern = struct
 
@@ -53,7 +53,7 @@ module Pattern = struct
       | i  -> Int32.shift_right_logical p i
 
     let check_mask m =
-      if m < 0l || m > 32l then
+      if Poly.(m < 0l || m > 32l) then
         failwith "Pattern.Ip: invalid mask"
 
     let shift (p, m) =
@@ -61,27 +61,27 @@ module Pattern = struct
       unsafe_shift (p, m)
 
     let less_eq (p1, m1) (p2, m2) =
-      m1 >= m2 && begin
+      Poly.(m1 >= m2) && begin
         check_mask m2;
-        unsafe_shift (p1, m2) = unsafe_shift (p2, m2)
+        Poly.(unsafe_shift (p1, m2) = unsafe_shift (p2, m2))
       end
 
     let eq (p1, m1) (p2, m2) =
-      m1 = m2 && (m1 = 0l || begin
+      Poly.(m1 = m2) && (Poly.(m1 = 0l) || begin
         check_mask m1;
-        unsafe_shift (p1, m1) = unsafe_shift (p2, m2)
+        Poly.(unsafe_shift (p1, m1) = unsafe_shift (p2, m2))
       end)
 
     let join (p1, m1) (p2, m2) =
       let rec loop m =
-        if m = 0l then
+        if Poly.(m = 0l) then
           (0l, 0l)
-        else if unsafe_shift (p1, m) = unsafe_shift (p2, m) then
+        else if Poly.(unsafe_shift (p1, m) = unsafe_shift (p2, m)) then
           (p1, m)
         else
           loop Int32.(m - 1l)
       in
-      let m = min m1 m2 in
+      let m = Poly.min m1 m2 in
       check_mask m;
       loop m
 
@@ -139,17 +139,17 @@ module Pattern = struct
             | None -> false
             | Some(v1) -> f v1 v2
           end in
-    check (=) p1.dlSrc p2.dlSrc
-    && check (=) p1.dlDst p2.dlDst
-    && check (=) p1.dlTyp p2.dlTyp
-    && check (=) p1.dlVlan p2.dlVlan
-    && check (=) p1.dlVlanPcp p2.dlVlanPcp
+    check Poly.(=) p1.dlSrc p2.dlSrc
+    && check Poly.(=) p1.dlDst p2.dlDst
+    && check Poly.(=) p1.dlTyp p2.dlTyp
+    && check Poly.(=) p1.dlVlan p2.dlVlan
+    && check Poly.(=) p1.dlVlanPcp p2.dlVlanPcp
     && check Ip.less_eq p1.nwSrc p2.nwSrc
     && check Ip.less_eq p1.nwDst p2.nwDst
-    && check (=) p1.nwProto p2.nwProto
-    && check (=) p1.tpSrc p2.tpSrc
-    && check (=) p1.tpDst p2.tpDst
-    && check (=) p1.inPort p2.inPort
+    && check Poly.(=) p1.nwProto p2.nwProto
+    && check Poly.(=) p1.tpSrc p2.tpSrc
+    && check Poly.(=) p1.tpDst p2.tpDst
+    && check Poly.(=) p1.inPort p2.inPort
 
   let eq p1 p2 =
     let check f m1 m2 =
@@ -157,20 +157,20 @@ module Pattern = struct
         | None   , None    -> true
         | Some v1, Some v2 -> f v1 v2
         | _      , _       -> false in
-    check (=) p1.dlSrc p2.dlSrc
-    && check (=) p1.dlDst p2.dlDst
-    && check (=) p1.dlTyp p2.dlTyp
-    && check (=) p1.dlVlan p2.dlVlan
-    && check (=) p1.dlVlanPcp p2.dlVlanPcp
+    check Poly.(=) p1.dlSrc p2.dlSrc
+    && check Poly.(=) p1.dlDst p2.dlDst
+    && check Poly.(=) p1.dlTyp p2.dlTyp
+    && check Poly.(=) p1.dlVlan p2.dlVlan
+    && check Poly.(=) p1.dlVlanPcp p2.dlVlanPcp
     && check Ip.eq p1.nwSrc p2.nwSrc
     && check Ip.eq p1.nwDst p2.nwDst
-    && check (=) p1.nwProto p2.nwProto
-    && check (=) p1.tpSrc p2.tpSrc
-    && check (=) p1.tpDst p2.tpDst
-    && check (=) p1.inPort p2.inPort
+    && check Poly.(=) p1.nwProto p2.nwProto
+    && check Poly.(=) p1.tpSrc p2.tpSrc
+    && check Poly.(=) p1.tpDst p2.tpDst
+    && check Poly.(=) p1.inPort p2.inPort
 
   let eq_join x1 x2 =
-    if x1 = x2 then Some x1 else None
+    if Poly.(x1 = x2) then Some x1 else None
 
   let join p1 p2 =
     let joiner m m1 m2 =
@@ -614,7 +614,7 @@ module To0x01 = struct
   exception Invalid_port of int32
 
   let from_portId (pport_id : portId) : OF10.portId =
-    if pport_id > 0xff00l then (* pport_id <= OFPP_MAX *)
+    if Poly.(pport_id > 0xff00l) then (* pport_id <= OFPP_MAX *)
       raise (Invalid_port pport_id)
     else
       Int32.to_int_exn pport_id
@@ -628,7 +628,7 @@ module To0x01 = struct
       | All -> Output AllPorts
       | Physical pport_id ->
         let pport_id = from_portId pport_id in
-        if Some pport_id = inPort then
+        if Poly.(Some pport_id = inPort) then
           Output InPort
         else
           Output (PhysicalPort pport_id)
@@ -643,7 +643,7 @@ module To0x01 = struct
         from_output inPort pseudoport
       | Enqueue (pport_id, queue_id) ->
         let pport_id = from_portId pport_id in
-        if Some pport_id = inPort then
+        if Poly.(Some pport_id = inPort) then
           Enqueue(InPort, queue_id)
         else
           Enqueue (PhysicalPort pport_id, queue_id)
@@ -708,7 +708,7 @@ module To0x01 = struct
       | None -> None
       | Some (p,m) ->
          let mo =
-           if m = 32l then
+           if Poly.(m = 32l) then
              None
            else
              Some (Int32.(32l - m)) in
@@ -717,7 +717,7 @@ module To0x01 = struct
       | None -> None
       | Some (p,m) ->
          let mo =
-           if m = 32l then
+           if Poly.(m = 32l) then
              None
            else
              Some (Int32.(32l - m)) in

--- a/src/lib/kernel/OpenFlow0x01.ml
+++ b/src/lib/kernel/OpenFlow0x01.ml
@@ -1516,10 +1516,10 @@ module PortDescription = struct
 
       let of_int d =
         let d_masked = Int32.bit_and d mask in
-        if d_masked = to_int Listen then Listen
-        else if d_masked = to_int Learn then Learn
-        else if d_masked = to_int Forward then Forward
-        else if d_masked = to_int Block then Block
+        if Poly.(d_masked = to_int Listen) then Listen
+        else if Poly.(d_masked = to_int Learn) then Learn
+        else if Poly.(d_masked = to_int Forward) then Forward
+        else if Poly.(d_masked = to_int Block) then Block
         else raise (Unparsable
           (Printf.sprintf "Unexpected ofp_port_state for STP: %ld" d_masked))
     end
@@ -2410,7 +2410,7 @@ module StatsReply = struct
               set_ofp_flow_stats_packet_count out (head.packet_count);
               set_ofp_flow_stats_byte_count out (head.byte_count)
         end;
-        (** TODO: Support the marshaling of multiple action and multiple flows *)
+        (* TODO: Support the marshaling of multiple action and multiple flows *)
         sizeof_ofp_stats_reply + sizeof_ofp_flow_stats
       | PortRep rep ->
         set_ofp_stats_reply_stats_type out (ofp_stats_types_to_int OFPST_PORT);
@@ -2433,7 +2433,7 @@ module StatsReply = struct
             set_ofp_port_stats_rx_crc_err out (head.rx_crc_err);
             set_ofp_port_stats_collisions out (head.collisions);
         end;
-        (** TODO: Support the marshaling of multiple action and multiple flows *)
+        (* TODO: Support the marshaling of multiple action and multiple flows *)
         sizeof_ofp_stats_reply + sizeof_ofp_port_stats
     end
 
@@ -2766,7 +2766,7 @@ module Error = struct
   [@@deriving sexp]
 
   type t =
-    | Error of c * Cstruct_sexp.t sexp_opaque
+    | Error of c * Cstruct_sexp.t [@sexp_opaque]
   [@@deriving sexp]
 
   let parse bits =
@@ -2840,7 +2840,7 @@ end
 
 module Vendor = struct
 
-  type t = int32 * Cstruct_sexp.t sexp_opaque
+  type t = int32 * Cstruct_sexp.t [@sexp_opaque]
   [@@deriving sexp]
 
   [%%cstruct

--- a/src/lib/kernel/OpenFlow0x01.mli
+++ b/src/lib/kernel/OpenFlow0x01.mli
@@ -88,8 +88,8 @@ type flowMod =
 [@@deriving sexp]
 
 type payload =
-  | Buffered of int32 * Cstruct.t sexp_opaque
-  | NotBuffered of Cstruct.t sexp_opaque
+  | Buffered of int32 * Cstruct.t [@sexp_opaque]
+  | NotBuffered of Cstruct.t [@sexp_opaque]
 [@@deriving sexp]
 
 type packetInReason =
@@ -609,7 +609,7 @@ module Error : sig
   [@@deriving sexp]
 
   type t =
-    | Error of c * Cstruct.t sexp_opaque
+    | Error of c * Cstruct.t [@sexp_opaque]
   [@@deriving sexp]
 
   (** [to_string v] pretty-prints [v]. *)
@@ -620,7 +620,7 @@ end
 (** A VENDOR message.  See Section 5.5.4 of the OpenFlow 1.0 specification. *)
 module Vendor : sig
 
-  type t = int32 * Cstruct.t sexp_opaque
+  type t = int32 * Cstruct.t [@sexp_opaque]
   [@@deriving sexp]
 
   val parse : Cstruct.t -> t

--- a/src/lib/kernel/Packet.ml
+++ b/src/lib/kernel/Packet.ml
@@ -1317,7 +1317,7 @@ let parse (bits : Cstruct.t) =
 
 let len (pkt : packet) =
   let eth_len =
-    if pkt.dlVlan <> None then sizeof_vlan
+    if Poly.(pkt.dlVlan <> None) then sizeof_vlan
     else sizeof_eth in
   let nw_len = match pkt.nw with
     | Ip ip -> Ip.len ip

--- a/src/lib/kernel/Topology.ml
+++ b/src/lib/kernel/Topology.ml
@@ -132,7 +132,7 @@ module Mininet = struct
             (topo, (loc, vertex) :: acc)) in
 
     (* Function to find a vertex from location *)
-    let find_vertex loc = List.Assoc.find_exn loc_tup_to_vertex_table ~equal:(=)
+    let find_vertex loc = List.Assoc.find_exn loc_tup_to_vertex_table ~equal:Poly.(=)
         (location_to_id loc) in
 
     (* Add all the edges to the topo *)

--- a/src/lib/kernel/dune
+++ b/src/lib/kernel/dune
@@ -5,5 +5,5 @@
  (libraries core base64 cstruct cstruct-sexp ocamlgraph open tcpip yojson ipaddr sedlex
    sexplib str menhirLib compiler-libs.common)
  (preprocess
-  (pps ppx_cstruct ppx_deriving.std ppx_jane))
+  (pps ppx_cstruct ppx_deriving.std ppx_jane -allow-unannotated-ignores))
 )

--- a/src/lib/netkat/Domain.ml
+++ b/src/lib/netkat/Domain.ml
@@ -32,7 +32,7 @@ and for_fdd dom fdd =
     residual trees below f-tests. *)
 and for_field f fdd vs residuals =
   match FDD.unget fdd with
-  | Branch {test=(f',v); tru; fls} when f' = f ->
+  | Branch {test=(f',v); tru; fls} when Poly.(f' = f) ->
     let vs = match v with Const v -> Set.add vs v | _ -> vs in
     for_field f fls vs (Set.add residuals tru)
   | Branch _ | Leaf _ ->

--- a/src/lib/netkat/Fdd.ml
+++ b/src/lib/netkat/Fdd.ml
@@ -67,7 +67,7 @@ module Field = struct
     (* using Obj.magic instead of to_enum for bettter performance *)
     Int.compare order.(Obj.magic x) order.(Obj.magic y)
 
-  let equal x y = x = y
+  let equal x y = Poly.(x = y)
 
   module type ENV = sig
     type t

--- a/src/lib/netkat/LexBuffer.ml
+++ b/src/lib/netkat/LexBuffer.ml
@@ -56,12 +56,12 @@ let cr = Uchar.of_char '\r'
 let next lexbuf =
   Option.map (Sedlexing.next lexbuf.buf) ~f:(fun c ->
     let pos = next_loc lexbuf in
-    begin match Uchar.to_char c with
+    begin match Uchar.to_char_exn c with
     | '\r' ->
       lexbuf.pos <- { pos with
         pos_bol = pos.pos_cnum - 1;
         pos_lnum = pos.pos_lnum + 1; }
-    | '\n' when not (lexbuf.last_char = Some cr) ->
+    | '\n' when not Poly.(lexbuf.last_char = Some cr) ->
       lexbuf.pos <- { pos with
         pos_bol = pos.pos_cnum - 1;
         pos_lnum = pos.pos_lnum + 1; }
@@ -75,7 +75,7 @@ let next lexbuf =
 
 let raw lexbuf : int array =
   Sedlexing.lexeme lexbuf.buf
-  |> Array.map ~f:Uchar.to_int
+  |> Array.map ~f:Uchar.to_scalar
 
 let ascii ?(skip=0) ?(drop=0) lexbuf : string =
   let len = Sedlexing.(lexeme_length lexbuf.buf - skip - drop) in

--- a/src/lib/netkat/Lexer.cppo.ml
+++ b/src/lib/netkat/Lexer.cppo.ml
@@ -1,6 +1,6 @@
 module Location = struct
   include Location
-  let pp = print
+  let pp = print_loc
 end
 
 (* FIXME: while ppx_import is not compatible with jbuilder, simply copy and paste
@@ -21,17 +21,20 @@ exception ParseError of (token * Lexing.position * Lexing.position)
 
 (** Register exceptions for pretty printing *)
 let _ =
-  let open Location in
-  register_error_of_exn (function
+  Location.register_error_of_exn (function
     | LexError (pos, msg) ->
-      let loc = { loc_start = pos; loc_end = pos; loc_ghost = false} in
-      Some { loc; msg; sub=[]; if_highlight=""; }
+      let loc = Location.{ loc_start = pos; loc_end = pos; loc_ghost = false} in
+      let main = Location.mkloc (fun fmt -> Format.fprintf fmt "%s" msg) loc in
+      let err = Location.{ kind = Report_error; main = main; sub=[] } in
+      Some err
     | ParseError (token, loc_start, loc_end) ->
       let loc = Location.{ loc_start; loc_end; loc_ghost = false} in
       let msg =
         show_token token
         |> Printf.sprintf "parse error while reading token '%s'" in
-      Some { loc; msg; sub=[]; if_highlight=""; }
+      let main = Location.mkloc (fun fmt -> Format.fprintf fmt "%s" msg) loc in
+      let err = Location.{ kind = Report_error; main = main; sub=[] } in
+      Some err
     | _ -> None)
 
 let failwith buf s = raise (LexError (buf.pos, s))

--- a/src/lib/netkat/Local_compiler.ml
+++ b/src/lib/netkat/Local_compiler.ml
@@ -97,7 +97,7 @@ module FDD = struct
       let alias = Field.of_hv ~env hv in
       let meta,_ = Field.Env.lookup env meta_field in
       fold t ~f:const ~g:(fun (field,v) tru fls ->
-        if field = meta then
+        if Poly.(field = meta) then
           cond (alias, v) tru fls
         else
           cond (field,v) tru fls)
@@ -501,7 +501,7 @@ let field_order_from_string = function
     |> List.map ~f:Field.of_string in
    let compose f g x = f (g x) in
    let curr_order = Field.all in
-   let removed = List.filter curr_order ~f:(compose not (List.mem ~equal:(=) ls)) in
+   let removed = List.filter curr_order ~f:(compose not (List.mem ~equal:Poly.(=) ls)) in
    (* Tags all specified Fields at the highest priority *)
    let new_order = List.append (List.rev ls) removed in
    (`Static new_order)
@@ -531,7 +531,7 @@ let field_order_to_string fo =
 let options_to_json_string opt =
   let open Yojson.Basic in
   `Assoc [
-    ("cache_prepare", `String (if opt.cache_prepare = `Keep then "keep" else "empty"));
+    ("cache_prepare", `String (if Poly.(opt.cache_prepare = `Keep) then "keep" else "empty"));
     ("field_order", `String (field_order_to_string opt.field_order));
     ("remove_tail_drops", `Bool opt.remove_tail_drops);
     ("dedup_flows", `Bool opt.dedup_flows);
@@ -592,14 +592,14 @@ let flow_table_subtrees (layout : flow_layout) (t : t) : flow_subtrees =
     | Leaf _ ->
        t :: subtrees
     | Branch { test = field, _; tru; fls } ->
-      if (List.mem ~equal:(=) table field) then
+      if (List.mem ~equal:Poly.(=) table field) then
         t :: subtrees
       else
         subtrees_for_table table tru subtrees
         |> subtrees_for_table table fls in
   let meta_id = ref 0 in
     List.map layout ~f:(fun table -> subtrees_for_table table t [])
-    |> List.filter ~f:(fun subtrees -> subtrees <> [])
+    |> List.filter ~f:(fun subtrees -> Poly.(subtrees <> []))
     |> List.foldi ~init:Map.Poly.empty ~f:(fun tbl_id accum subtrees ->
       List.fold_right subtrees ~init:accum ~f:(fun t accum ->
         Map.set accum ~key:t ~data:(tbl_id,(post meta_id))))

--- a/src/lib/netkat/Optimize.ml
+++ b/src/lib/netkat/Optimize.ml
@@ -77,7 +77,7 @@ let specialize_pred sw pr =
       | Neg pr1 ->
         loop pr1 (fun pr -> k (mk_not pr))
       | Test (Switch v) ->
-        if v = sw then
+        if Poly.(v = sw) then
           k True
         else
           k False

--- a/src/lib/netkat/Packet.mli
+++ b/src/lib/netkat/Packet.mli
@@ -13,7 +13,7 @@ module T : sig
   include Comparator.S with type t := t
 end
 
-include T with type t = int64 Map.M(Field).t
+include T with type t = int64 Map.M(Field).t [@deriving sexp, compare, hash]
 
 (** the packet with no fields *)
 val empty : t

--- a/src/lib/netkat/Portless_Compiler.ml
+++ b/src/lib/netkat/Portless_Compiler.ml
@@ -17,7 +17,7 @@ let connected_switches ~loc ~direction ~topo =
     let neighbors = Topology.neighbors network loc in
     Topology.VertexSet.fold neighbors ~init:[] ~f:(fun acc other ->
         let node = Topology.vertex_to_label network other in
-        if Network.Node.device node = Switch then
+        if Poly.(Network.Node.device node = Switch) then
           let edges = match direction with
             | Incoming -> Topology.find_all_edges network other loc
             | Outgoing -> Topology.find_all_edges network loc other in
@@ -35,7 +35,7 @@ let abs_loc_to_switch (topo: topo) loc =
   match vertex with
   | Some v ->
     let node = (Topology.vertex_to_label network v) in
-    if Network.Node.device node = Switch then
+    if Poly.(Network.Node.device node = Switch) then
       Network.Node.id node
     else
       failwith "the location is not a switch"
@@ -45,7 +45,7 @@ let is_loc_host (topo: topo) loc =
   let (name_to_vertex_table, network) = topo in
   let vertex = Hashtbl.find name_to_vertex_table loc in
   match vertex with
-  | Some v -> Network.Node.device (Topology.vertex_to_label network v) = Host
+  | Some v -> Poly.(Network.Node.device (Topology.vertex_to_label network v) = Host)
   | None -> failwith "no such location"
 
 

--- a/src/lib/netkat/Vlr.ml
+++ b/src/lib/netkat/Vlr.ml
@@ -81,7 +81,7 @@ module Make(V:HashCmp)(L:Lattice)(R:Result) = struct
     if equal tru fls then
       fls
     else match unget fls with
-    | Branch { test = (v',_); all_fls; _ } when v=v' ->
+    | Branch { test = (v',_); all_fls; _ } when Poly.(v=v') ->
       if all_fls = tru then
         fls
       else
@@ -129,7 +129,7 @@ module Make(V:HashCmp)(L:Lattice)(R:Result) = struct
         |  1 -> mk_branch (v',l') (loop xs t) (loop xs f)
         |  _ -> assert false
     in
-    loop (List.sort (fun (u, _) (v, _) -> V.compare u v) lst) u
+    loop (List.sort lst ~compare:(fun (u, _) (v, _) -> V.compare u v)) u
 
   let apply f zero ~(cache: (t*t, t) Hashtbl.t) =
     let rec sum x y =

--- a/src/lib/netkat/dune
+++ b/src/lib/netkat/dune
@@ -66,5 +66,5 @@
    ipaddr sedlex sexplib str menhirLib compiler-libs.common)
  (virtual_deps cppo menhir)
  (preprocess
-  (pps ppx_cstruct ppx_deriving.std ppx_jane sedlex.ppx))
+  (pps ppx_cstruct ppx_deriving.std ppx_jane -allow-unannotated-ignores sedlex.ppx))
  (flags :standard -safe-string))


### PR DESCRIPTION
@smolkaj Could you take a look at this?

I updated to OCaml 4.11.0 and the latest libraries from OPAM. I was able to eliminate almost all of the compiler errors except one that I can't figure out:
```
File "src/lib/netkat/Fdd.ml", line 495, characters 6-20:
495 |       | F of Field.t
            ^^^^^^^^^^^^^^
Error: This expression has type Field.t
       but an expression was expected of type int
```
The error message makes no sense. 

Is this due to some deriving nonsense?