### PR TITLE
update for tcpip 7.0.0, where the checksum module is now part of tcpip.checksum

### DIFF
--- a/frenetic.opam
+++ b/frenetic.opam
@@ -35,7 +35,7 @@ depends: [
   "ppx_deriving" {>= "5.1"}
   "sedlex" {>= "2.4" }
   "sexplib" {>= "v0.14.0"}
-  "tcpip" {>= "6.3.0"}
+  "tcpip" {>= "7.0.0"}
   "yojson" {>= "1.7.0"}
 ]
 url {

--- a/src/lib/kernel/dune
+++ b/src/lib/kernel/dune
@@ -2,7 +2,7 @@
  (name frenetic_kernel)
  (public_name frenetic.kernel)
  (wrapped true)
- (libraries core base64 cstruct cstruct-sexp ocamlgraph open tcpip tcpip.unix yojson ipaddr sedlex
+ (libraries core base64 cstruct cstruct-sexp ocamlgraph open tcpip tcpip.checksum yojson ipaddr sedlex
    sexplib str menhirLib compiler-libs.common)
  (preprocess
   (pps ppx_cstruct ppx_deriving.std ppx_jane -allow-unannotated-ignores))


### PR DESCRIPTION
and the deprecated tcpip.unix is no longer provided